### PR TITLE
fix: spacing のXY が逆になってたので修正

### DIFF
--- a/packages/wiz-ui/src/utils/styles/spacing.ts
+++ b/packages/wiz-ui/src/utils/styles/spacing.ts
@@ -7,4 +7,4 @@ export const getSpacingCSS = (spacings?: SpacingKeys) =>
 export const getCoupleSpacingCSS = (
   spacingX?: SpacingKeys,
   spacingY?: SpacingKeys
-) => `${SPACING_MAP[spacingX || "no"]} ${SPACING_MAP[spacingY || "no"]}`;
+) => `${SPACING_MAP[spacingY || "no"]} ${SPACING_MAP[spacingX || "no"]}`;


### PR DESCRIPTION
# タスク

spacing の x, y が逆になっていたので修正

## 動作確認

before| after
---|---
<video src="https://user-images.githubusercontent.com/29594820/206915581-86579497-95f2-49ac-859e-3663c9f5a8e1.mov"></video> | <video src="https://user-images.githubusercontent.com/29594820/206915604-20f1b706-828b-4f1e-b4c7-4c6fe2462137.mov"></video>**




<!-- reviewerに@sor4chiを追加してください-->
