### PR TITLE
fix:wiz-stackでgxとgyを両方指定した際にgxが効かないバグの修正

### DIFF
--- a/packages/styles/commons/gap.css.ts
+++ b/packages/styles/commons/gap.css.ts
@@ -6,9 +6,9 @@ export const gapStyle = styleVariants(SPACING_MAP, (gap) => ({
 }));
 
 export const gapXStyle = styleVariants(SPACING_MAP, (gapX) => ({
-  gap: `0 ${gapX}`,
+  columnGap: `${gapX}`,
 }));
 
 export const gapYStyle = styleVariants(SPACING_MAP, (gapY) => ({
-  gap: `${gapY} 0`,
+  rowGap: `${gapY}`,
 }));

--- a/packages/styles/commons/gap.css.ts
+++ b/packages/styles/commons/gap.css.ts
@@ -6,9 +6,9 @@ export const gapStyle = styleVariants(SPACING_MAP, (gap) => ({
 }));
 
 export const gapXStyle = styleVariants(SPACING_MAP, (gapX) => ({
-  columnGap: `${gapX}`,
+  columnGap: gapX,
 }));
 
 export const gapYStyle = styleVariants(SPACING_MAP, (gapY) => ({
-  rowGap: `${gapY}`,
+  rowGap: gapY,
 }));


### PR DESCRIPTION
# タスク

resolve: #253 

<!-- reviewerに@sor4chiを追加してください-->
