### PR TITLE
[#433] 検索精度の向上

### DIFF
--- a/packages/wiz-ui-next/src/components/base/inputs/search-selector/levenshtein-distance.ts
+++ b/packages/wiz-ui-next/src/components/base/inputs/search-selector/levenshtein-distance.ts
@@ -2,11 +2,11 @@ export const levenshteinDistance = (s1: string, s2: string): number => {
   const dist: number[][] = Array.from({ length: s1.length + 1 }, () =>
     Array(s2.length + 1).fill(0)
   );
-  for (let i = 0; i < s1.length; i++) dist[i][0] = i;
-  for (let i = 0; i < s2.length; i++) dist[0][i] = i;
-  for (let i = 1; i < s1.length; i++) {
-    for (let j = 1; j < s2.length; j++) {
-      const cost = s1[i] === s2[j] ? 0 : 1;
+  for (let i = 0; i < s1.length + 1; i++) dist[i][0] = i;
+  for (let i = 0; i < s2.length + 1; i++) dist[0][i] = i;
+  for (let i = 1; i < s1.length + 1; i++) {
+    for (let j = 1; j < s2.length + 1; j++) {
+      const cost = s1[i - 1] === s2[j - 1] ? 0 : 1;
       dist[i][j] = Math.min(
         dist[i - 1][j] + 1,
         dist[i][j - 1] + 1,
@@ -14,5 +14,5 @@ export const levenshteinDistance = (s1: string, s2: string): number => {
       );
     }
   }
-  return dist[s1.length - 1][s2.length - 1] / Math.max(s1.length, s2.length);
+  return dist[s1.length][s2.length] / Math.max(s1.length, s2.length);
 };

--- a/packages/wiz-ui/src/components/base/inputs/search-selector/levenshtein-distance.ts
+++ b/packages/wiz-ui/src/components/base/inputs/search-selector/levenshtein-distance.ts
@@ -2,11 +2,11 @@ export const levenshteinDistance = (s1: string, s2: string): number => {
   const dist: number[][] = Array.from({ length: s1.length + 1 }, () =>
     Array(s2.length + 1).fill(0)
   );
-  for (let i = 0; i < s1.length; i++) dist[i][0] = i;
-  for (let i = 0; i < s2.length; i++) dist[0][i] = i;
-  for (let i = 1; i < s1.length; i++) {
-    for (let j = 1; j < s2.length; j++) {
-      const cost = s1[i] === s2[j] ? 0 : 1;
+  for (let i = 0; i < s1.length + 1; i++) dist[i][0] = i;
+  for (let i = 0; i < s2.length + 1; i++) dist[0][i] = i;
+  for (let i = 1; i < s1.length + 1; i++) {
+    for (let j = 1; j < s2.length + 1; j++) {
+      const cost = s1[i - 1] === s2[j - 1] ? 0 : 1;
       dist[i][j] = Math.min(
         dist[i - 1][j] + 1,
         dist[i][j - 1] + 1,
@@ -14,5 +14,5 @@ export const levenshteinDistance = (s1: string, s2: string): number => {
       );
     }
   }
-  return dist[s1.length - 1][s2.length - 1] / Math.max(s1.length, s2.length);
+  return dist[s1.length][s2.length] / Math.max(s1.length, s2.length);
 };


### PR DESCRIPTION
# タスク

resolve: #433

検索に用いられたアルゴリズムで、For 文での調査範囲が間違っていたので修正した。

## 動作検証

...|before|after
---|---|---
動作|<video src="https://user-images.githubusercontent.com/29594820/224116033-30244099-ee43-4c4d-94b0-059c2dffd355.mov"/>|<video src="https://user-images.githubusercontent.com/29594820/224115864-491e90d8-e979-4d9d-8064-4b49648fa6f8.mov"/>
精度(20 を検索した場合)|![スクリーンショット 2023-03-10 1 47 12](https://user-images.githubusercontent.com/29594820/224094604-4ea44016-3d65-49d5-9fd7-2ea9e67c34b6.png)|![スクリーンショット 2023-03-10 2 34 58](https://user-images.githubusercontent.com/29594820/224109254-58611522-e652-44f6-bde4-d598272562b2.png)

<!-- reviewerにオーナーを追加してください-->
