### PR TITLE
Tooltip の Gap を統一

### DIFF
--- a/.changeset/cold-drinks-rhyme.md
+++ b/.changeset/cold-drinks-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@wizleap-inc/wiz-ui": patch
+---
+
+fix: gap definition

--- a/packages/wiz-ui/src/components/base/tooltip/tooltip.vue
+++ b/packages/wiz-ui/src/components/base/tooltip/tooltip.vue
@@ -13,7 +13,7 @@
         :shadow="false"
         :animation="true"
         @onTurn="turnPopup"
-        gap="xs"
+        gap="xs2"
       >
         <div
           :class="[tooltipPositionStyle[actuallyDirection], tooltipPopupStyle]"


### PR DESCRIPTION
# タスク

resolve #661 

Tooltip で gap の定義が wiz-ui と　wiz-ui-next とで異なっていたため、Slack にて相談ののち、 `xs2` に統一した。

https://wizleap.slack.com/archives/C03UB1CL2LS/p1681994105252749

![スクリーンショット 2023-04-20 21 33 53](https://user-images.githubusercontent.com/29594820/233374826-68cc26e8-c7a4-4a9a-8720-2706a42b1a1c.png)


<!-- reviewerにオーナーを追加してください-->
