### PR TITLE
Popup で影が残るバグを修正

### DIFF
--- a/.changeset/tiny-doors-warn.md
+++ b/.changeset/tiny-doors-warn.md
@@ -1,0 +1,6 @@
+---
+"@wizleap-inc/wiz-ui-next": patch
+"@wizleap-inc/wiz-ui": pathch
+---
+
+Popup の影が残るバグの修正

--- a/packages/wiz-ui-next/src/components/base/popup/popup.vue
+++ b/packages/wiz-ui-next/src/components/base/popup/popup.vue
@@ -9,7 +9,7 @@
       ]"
       :style="{
         inset,
-        transform: popupTranslate,
+        transform: `${popupTranslate} translateZ(0)`,
       }"
       ref="popupRef"
       @mouseleave="mouseLeave"

--- a/packages/wiz-ui/src/components/base/popup/popup.vue
+++ b/packages/wiz-ui/src/components/base/popup/popup.vue
@@ -9,7 +9,7 @@
       ]"
       :style="{
         inset,
-        transform: popupTranslate,
+        transform: `${popupTranslate} translateZ(0)`,
       }"
       ref="popupRef"
       @mouseleave="mouseLeave"


### PR DESCRIPTION
# タスク

resolve:  #615 

- https://qiita.com/siy1121/items/d5a5f198744cf882ef02#%E6%96%B9%E6%B3%95%EF%BC%91 

この記事の参照を元に、`translateZ(0)` を追加するとバグが解消されることを確認

<!-- reviewerにオーナーを追加してください-->
