### PR TITLE
chore: eslint-plugin-react-hooks を設定

### DIFF
--- a/.eslintrc.react.json
+++ b/.eslintrc.react.json
@@ -1,8 +1,15 @@
 {
-  "plugins": ["react"],
+  "plugins": ["react", "react-hooks"],
   "extends": ["plugin:react/recommended"],
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  },
   "rules": {
     "react/jsx-uses-react": "off",
-    "react/react-in-jsx-scope": "off"
+    "react/react-in-jsx-scope": "off",
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-react": "^7.32.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-unused-imports": "^2.0.0",
     "eslint-plugin-vue": "^9.7.0",
     "http-server": "^14.1.1",

--- a/packages/wiz-ui-react/src/components/base/stack/stories/h-stack.stories.tsx
+++ b/packages/wiz-ui-react/src/components/base/stack/stories/h-stack.stories.tsx
@@ -62,6 +62,8 @@ const Boxes = (props: { count: number }) => (
 
 export const Default: Story = {
   render: (args) => {
+    // FYI: https://github.com/storybookjs/storybook/issues/21115
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const [boxCount, setBoxCount] = useState(5);
     return (
       <div

--- a/packages/wiz-ui-react/src/components/base/stack/stories/stack.stories.tsx
+++ b/packages/wiz-ui-react/src/components/base/stack/stories/stack.stories.tsx
@@ -86,6 +86,7 @@ const Boxes = (props: { count: number }) => (
 
 export const Default: Story = {
   render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const [boxCount, setBoxCount] = useState(5);
     return (
       <>
@@ -110,6 +111,7 @@ export const Horizontal: Story = {
     direction: "horizontal",
   },
   render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const [boxCount, setBoxCount] = useState(5);
     return (
       <>
@@ -134,6 +136,7 @@ export const Vertical: Story = {
     direction: "vertical",
   },
   render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const [boxCount, setBoxCount] = useState(5);
     return (
       <>

--- a/packages/wiz-ui-react/src/components/base/stack/stories/v-stack.stories.tsx
+++ b/packages/wiz-ui-react/src/components/base/stack/stories/v-stack.stories.tsx
@@ -62,6 +62,7 @@ const Boxes = (props: { count: number }) => (
 
 export const Default: Story = {
   render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const [boxCount, setBoxCount] = useState(5);
     return (
       <div

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,6 +70,9 @@ importers:
       eslint-plugin-react:
         specifier: ^7.32.2
         version: 7.32.2(eslint@8.37.0)
+      eslint-plugin-react-hooks:
+        specifier: ^4.6.0
+        version: 4.6.0(eslint@8.37.0)
       eslint-plugin-unused-imports:
         specifier: ^2.0.0
         version: 2.0.0(@typescript-eslint/eslint-plugin@5.57.0)(eslint@8.37.0)
@@ -10405,6 +10408,15 @@ packages:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
+    dev: true
+
+  /eslint-plugin-react-hooks@4.6.0(eslint@8.37.0):
+    resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
+    dependencies:
+      eslint: 8.37.0
     dev: true
 
   /eslint-plugin-react@7.32.2(eslint@8.37.0):


### PR DESCRIPTION
# タスク

React hooks を書く上でこのlintが効かないと結構大変だと思うので追加しました。

FYI: https://ja.legacy.reactjs.org/docs/hooks-rules.html#eslint-plugin