### PR TITLE
card table  での hover のバグ修正

### DIFF
--- a/.changeset/dull-gifts-do.md
+++ b/.changeset/dull-gifts-do.md
@@ -1,0 +1,7 @@
+---
+"@wizleap-inc/wiz-ui-next": minor
+"@wizleap-inc/wiz-ui-styles": minor
+"@wizleap-inc/wiz-ui": minor
+---
+
+add css styles on safari only

--- a/.changeset/dull-gifts-do.md
+++ b/.changeset/dull-gifts-do.md
@@ -1,7 +1,8 @@
 ---
-"@wizleap-inc/wiz-ui-next": minor
-"@wizleap-inc/wiz-ui-styles": minor
-"@wizleap-inc/wiz-ui": minor
+"@wizleap-inc/wiz-ui-next": patch
+"@wizleap-inc/wiz-ui-styles": patch
+"@wizleap-inc/wiz-ui": patch
+"@wizleap-inc/wiz-ui-react": patch
 ---
 
-add css styles on safari only
+fix(card-table): card-table の safari 対応

--- a/packages/styles/bases/card-table.css.ts
+++ b/packages/styles/bases/card-table.css.ts
@@ -19,6 +19,26 @@ export const cardTdStyle = style({
   },
 });
 
+export const cardTdOnSafariStyle = style({
+  padding: `${THEME.spacing.sm} ${THEME.spacing.sm}`,
+  position: "relative",
+  ":after": {
+    content: "''",
+    position: "absolute",
+    top: "50%",
+    right: "-1px",
+    transform: "translateY(-50%)",
+    width: "1px",
+    height: `calc(100% - ${THEME.spacing.md})`,
+    backgroundColor: THEME.color.gray[300],
+  },
+  selectors: {
+    "&:last-child::after ": {
+      display: "none",
+    },
+  },
+});
+
 export const cardThStyle = style({
   color: THEME.color.gray[500],
   fontSize: THEME.fontSize.xs2,

--- a/packages/styles/bases/card-table.css.ts
+++ b/packages/styles/bases/card-table.css.ts
@@ -6,6 +6,11 @@ export const cardTableStyle = style({
   borderSpacing: `0 calc(${THEME.spacing.xs2} + ${THEME.spacing.xs} * 2)`,
 });
 
+export const cardTableOnSafariStyle = style({
+  borderCollapse: "separate",
+  borderSpacing: `0 ${THEME.spacing.xs}`,
+});
+
 export const cardTableFixedStyle = style({
   tableLayout: "fixed",
 });
@@ -43,6 +48,13 @@ export const cardThStyle = style({
   color: THEME.color.gray[500],
   fontSize: THEME.fontSize.xs2,
   fontWeight: "normal",
+});
+
+export const cardThOnSafariStyle = style({
+  color: THEME.color.gray[500],
+  fontSize: THEME.fontSize.xs2,
+  fontWeight: "normal",
+  height: THEME.spacing.xl3,
 });
 
 export const cardTrStyle = style({

--- a/packages/styles/bases/card-table.css.ts
+++ b/packages/styles/bases/card-table.css.ts
@@ -57,3 +57,32 @@ export const cardTrStyle = style({
     },
   },
 });
+
+export const cardTrOnSafariStyle = style({
+  selectors: {
+    "tbody > &": {
+      cursor: "pointer",
+      content: "",
+      top: 0,
+      left: 0,
+      width: "100%",
+      height: `calc(100% + ${THEME.spacing.xs} * 2)`,
+      transform: `translateY(calc(-1 * ${THEME.spacing.xs}))`,
+      borderRadius: THEME.spacing.xs2,
+      background: THEME.color.white[800],
+      zIndex: -1,
+      boxSizing: "border-box",
+      outline: `1px solid ${THEME.color.gray[300]}`,
+    },
+    "tbody > &:hover": {
+      "@media": {
+        "(any-hover: hover)": {
+          outline: `2px solid ${THEME.color.green[800]}`,
+        },
+      },
+    },
+    "tbody > &:active": {
+      background: THEME.color.green[300],
+    },
+  },
+});

--- a/packages/wiz-ui-next/src/components/base/tables/card/hooks/use-is-safari.ts
+++ b/packages/wiz-ui-next/src/components/base/tables/card/hooks/use-is-safari.ts
@@ -1,0 +1,4 @@
+export const useIsSafari = () => {
+  const ua = navigator.userAgent.toLowerCase();
+  return ua.indexOf("safari") !== -1 && ua.indexOf("chrome") === -1;
+};

--- a/packages/wiz-ui-next/src/components/base/tables/card/table.stories.ts
+++ b/packages/wiz-ui-next/src/components/base/tables/card/table.stories.ts
@@ -75,17 +75,17 @@ router-pushなどと組み合わせて、クリックした行に対応するペ
       </WizCardTr>
     </WizCardThead>
     <WizCardTbody>
-      <WizCardTr @click="onClick('Row 1')">
+      <WizCardTr @click="args.onClick('Row 1')">
         <WizCardTd>Row 1</WizCardTd>
         <WizCardTd>Row 1</WizCardTd>
         <WizCardTd>Row 1</WizCardTd>
       </WizCardTr>
-      <WizCardTr @click="onClick('Row 2')">
+      <WizCardTr @click="args.onClick('Row 2')">
         <WizCardTd>Row 2</WizCardTd>
         <WizCardTd>Row 2</WizCardTd>
         <WizCardTd>Row 2</WizCardTd>
       </WizCardTr>
-      <WizCardTr @click="onClick('Row 3')">
+      <WizCardTr @click="args.onClick('Row 3')">
         <WizCardTd>Row 3</WizCardTd>
         <WizCardTd>Row 3</WizCardTd>
         <WizCardTd>Row 3</WizCardTd>
@@ -127,7 +127,7 @@ export const Fixed: StoryFn<typeof WizCardTable> = (args) => ({
         </WizCardTr>
       </WizCardThead>
       <WizCardTbody>
-        <WizCardTr v-for="i in 3" @click="onClick('Row ' + i)">
+        <WizCardTr v-for="i in 3" @click="args.onClick('Row ' + i)">
           <WizCardTd v-for="j in 3" :key="j">
             Row {{ i }}
           </WizCardTd>
@@ -159,7 +159,7 @@ export const UnionColumn: StoryFn<typeof WizCardTable> = (args) => ({
         </WizCardTr>
       </WizCardThead>
       <WizCardTbody>
-        <WizCardTr v-for="i in 3" :key="i" @click="onClick('Row ' + i)">
+        <WizCardTr v-for="i in 3" :key="i" @click="args.onClick('Row ' + i)">
           <WizCardTd v-for="j in 4" :key="j">Row {{ i }}</WizCardTd>
         </WizCardTr>
       </WizCardTbody>
@@ -182,19 +182,19 @@ UnionColumn.parameters = {
       </WizCardTr>
     </WizCardThead>
     <WizCardTbody>
-      <WizCardTr @click="onClick('Row 1')">
+      <WizCardTr @click="args.onClick('Row 1')">
         <WizCardTd>Row 1</WizCardTd>
         <WizCardTd>Row 1</WizCardTd>
         <WizCardTd>Row 1</WizCardTd>
         <WizCardTd>Row 1</WizCardTd>
       </WizCardTr>
-      <WizCardTr @click="onClick('Row 2')">
+      <WizCardTr @click="args.onClick('Row 2')">
         <WizCardTd>Row 2</WizCardTd>
         <WizCardTd>Row 2</WizCardTd>
         <WizCardTd>Row 2</WizCardTd>
         <WizCardTd>Row 2</WizCardTd>
       </WizCardTr>
-      <WizCardTr @click="onClick('Row 3')">
+      <WizCardTr @click="args.onClick('Row 3')">
         <WizCardTd>Row 3</WizCardTd>
         <WizCardTd>Row 3</WizCardTd>
         <WizCardTd>Row 3</WizCardTd>

--- a/packages/wiz-ui-next/src/components/base/tables/card/table.vue
+++ b/packages/wiz-ui-next/src/components/base/tables/card/table.vue
@@ -1,6 +1,9 @@
 <template>
   <table
-    :class="[cardTableStyle, fixed && cardTableFixedStyle]"
+    :class="[
+      isSafari ? cardTableOnSafariStyle : cardTableStyle,
+      fixed && cardTableFixedStyle,
+    ]"
     :style="{ width }"
   >
     <slot />
@@ -12,7 +15,10 @@ import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
 import {
   cardTableStyle,
   cardTableFixedStyle,
+  cardTableOnSafariStyle,
 } from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
+
+import { useIsSafari } from "./hooks/use-is-safari";
 
 defineOptions({
   name: ComponentName.CardTable,
@@ -29,4 +35,6 @@ defineProps({
     required: false,
   },
 });
+
+const isSafari = useIsSafari();
 </script>

--- a/packages/wiz-ui-next/src/components/base/tables/card/table.vue
+++ b/packages/wiz-ui-next/src/components/base/tables/card/table.vue
@@ -1,8 +1,8 @@
 <template>
   <table
     :class="[
-      isSafari ? cardTableOnSafariStyle : cardTableStyle,
-      fixed && cardTableFixedStyle,
+      isSafari ? styles.cardTableOnSafariStyle : styles.cardTableStyle,
+      fixed && styles.cardTableFixedStyle,
     ]"
     :style="{ width }"
   >
@@ -12,11 +12,7 @@
 
 <script setup lang="ts">
 import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
-import {
-  cardTableStyle,
-  cardTableFixedStyle,
-  cardTableOnSafariStyle,
-} from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
+import * as styles from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
 
 import { useIsSafari } from "./hooks/use-is-safari";
 

--- a/packages/wiz-ui-next/src/components/base/tables/card/td.vue
+++ b/packages/wiz-ui-next/src/components/base/tables/card/td.vue
@@ -1,12 +1,21 @@
 <template>
-  <td :class="cardTdStyle" :rowSpan="rowSpan" :colSpan="colSpan">
+  <td
+    :class="isSafari ? cardTdOnSafariStyle : cardTdStyle"
+    :rowSpan="rowSpan"
+    :colSpan="colSpan"
+  >
     <slot />
   </td>
 </template>
 
 <script setup lang="ts">
 import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
-import { cardTdStyle } from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
+import {
+  cardTdStyle,
+  cardTdOnSafariStyle,
+} from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
+
+import { useIsSafari } from "./hooks/use-is-safari";
 
 defineOptions({
   name: ComponentName.CardTd,
@@ -22,4 +31,6 @@ defineProps({
     required: false,
   },
 });
+
+const isSafari = useIsSafari();
 </script>

--- a/packages/wiz-ui-next/src/components/base/tables/card/td.vue
+++ b/packages/wiz-ui-next/src/components/base/tables/card/td.vue
@@ -1,6 +1,6 @@
 <template>
   <td
-    :class="isSafari ? cardTdOnSafariStyle : cardTdStyle"
+    :class="isSafari ? styles.cardTdOnSafariStyle : styles.cardTdStyle"
     :rowSpan="rowSpan"
     :colSpan="colSpan"
   >
@@ -10,10 +10,7 @@
 
 <script setup lang="ts">
 import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
-import {
-  cardTdStyle,
-  cardTdOnSafariStyle,
-} from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
+import * as styles from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
 
 import { useIsSafari } from "./hooks/use-is-safari";
 

--- a/packages/wiz-ui-next/src/components/base/tables/card/th.vue
+++ b/packages/wiz-ui-next/src/components/base/tables/card/th.vue
@@ -1,6 +1,6 @@
 <template>
   <th
-    :class="isSafari ? cardThOnSafariStyle : cardThStyle"
+    :class="isSafari ? styles.cardThOnSafariStyle : styles.cardThStyle"
     :style="{ width }"
     :rowSpan="rowSpan"
     :colSpan="colSpan"
@@ -11,10 +11,7 @@
 
 <script setup lang="ts">
 import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
-import {
-  cardThStyle,
-  cardThOnSafariStyle,
-} from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
+import * as styles from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
 
 import { useIsSafari } from "./hooks/use-is-safari";
 

--- a/packages/wiz-ui-next/src/components/base/tables/card/th.vue
+++ b/packages/wiz-ui-next/src/components/base/tables/card/th.vue
@@ -1,6 +1,6 @@
 <template>
   <th
-    :class="cardThStyle"
+    :class="isSafari ? cardThOnSafariStyle : cardThStyle"
     :style="{ width }"
     :rowSpan="rowSpan"
     :colSpan="colSpan"
@@ -11,7 +11,12 @@
 
 <script setup lang="ts">
 import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
-import { cardThStyle } from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
+import {
+  cardThStyle,
+  cardThOnSafariStyle,
+} from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
+
+import { useIsSafari } from "./hooks/use-is-safari";
 
 defineOptions({
   name: ComponentName.CardTh,
@@ -32,4 +37,6 @@ defineProps({
     required: false,
   },
 });
+
+const isSafari = useIsSafari();
 </script>

--- a/packages/wiz-ui-next/src/components/base/tables/card/tr.vue
+++ b/packages/wiz-ui-next/src/components/base/tables/card/tr.vue
@@ -1,12 +1,16 @@
 <template>
-  <tr :class="cardTrStyle" @click="onClick">
+  <tr :class="[isSafari ? cardTrOnSafariStyle : cardTrStyle]" @click="onClick">
     <slot />
   </tr>
 </template>
 
 <script setup lang="ts">
 import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
-import { cardTrStyle } from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
+import {
+  cardTrStyle,
+  cardTrOnSafariStyle,
+} from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
+import { computed } from "vue";
 
 defineOptions({
   name: ComponentName.CardTr,
@@ -19,4 +23,9 @@ interface Emits {
 const emits = defineEmits<Emits>();
 
 const onClick = () => emits("click");
+
+const isSafari = computed(() => {
+  const ua = navigator.userAgent.toLowerCase();
+  return ua.indexOf("safari") !== -1 && ua.indexOf("chrome") === -1;
+});
 </script>

--- a/packages/wiz-ui-next/src/components/base/tables/card/tr.vue
+++ b/packages/wiz-ui-next/src/components/base/tables/card/tr.vue
@@ -10,7 +10,8 @@ import {
   cardTrStyle,
   cardTrOnSafariStyle,
 } from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
-import { computed } from "vue";
+
+import { useIsSafari } from "./hooks/use-is-safari";
 
 defineOptions({
   name: ComponentName.CardTr,
@@ -24,8 +25,5 @@ const emits = defineEmits<Emits>();
 
 const onClick = () => emits("click");
 
-const isSafari = computed(() => {
-  const ua = navigator.userAgent.toLowerCase();
-  return ua.indexOf("safari") !== -1 && ua.indexOf("chrome") === -1;
-});
+const isSafari = useIsSafari();
 </script>

--- a/packages/wiz-ui-next/src/components/base/tables/card/tr.vue
+++ b/packages/wiz-ui-next/src/components/base/tables/card/tr.vue
@@ -1,15 +1,15 @@
 <template>
-  <tr :class="[isSafari ? cardTrOnSafariStyle : cardTrStyle]" @click="onClick">
+  <tr
+    :class="[isSafari ? styles.cardTrOnSafariStyle : styles.cardTrStyle]"
+    @click="onClick"
+  >
     <slot />
   </tr>
 </template>
 
 <script setup lang="ts">
 import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
-import {
-  cardTrStyle,
-  cardTrOnSafariStyle,
-} from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
+import * as styles from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
 
 import { useIsSafari } from "./hooks/use-is-safari";
 

--- a/packages/wiz-ui-react/src/components/base/tables/card/components/card-table.tsx
+++ b/packages/wiz-ui-react/src/components/base/tables/card/components/card-table.tsx
@@ -3,6 +3,8 @@ import * as styles from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
 import clsx from "clsx";
 import { ComponentProps, ReactNode } from "react";
 
+import { useIsSafari } from "../hooks/use-is-safari";
+
 type Props = {
   fixed?: boolean;
   width?: string;
@@ -10,10 +12,11 @@ type Props = {
 } & ComponentProps<"table">;
 
 const CardTable = ({ fixed = false, width, children, ...props }: Props) => {
+  const isSafari = useIsSafari();
   return (
     <table
       className={clsx(
-        styles.cardTableStyle,
+        isSafari ? styles.cardTableOnSafariStyle : styles.cardTableStyle,
         fixed && styles.cardTableFixedStyle
       )}
       style={{ width }}

--- a/packages/wiz-ui-react/src/components/base/tables/card/components/card-td.tsx
+++ b/packages/wiz-ui-react/src/components/base/tables/card/components/card-td.tsx
@@ -2,15 +2,23 @@ import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
 import * as styles from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
 import { ComponentProps, ReactNode } from "react";
 
+import { useIsSafari } from "../hooks/use-is-safari";
+
 type Props = {
   children?: ReactNode;
 } & ComponentProps<"td">;
 
-const CardTd = ({ children, ...props }: Props) => (
-  <td className={styles.cardTdStyle} {...props}>
-    {children}
-  </td>
-);
+const CardTd = ({ children, ...props }: Props) => {
+  const isSafari = useIsSafari();
+  return (
+    <td
+      className={isSafari ? styles.cardTdOnSafariStyle : styles.cardTdStyle}
+      {...props}
+    >
+      {children}
+    </td>
+  );
+};
 
 CardTd.displayName = ComponentName.CardTd;
 

--- a/packages/wiz-ui-react/src/components/base/tables/card/components/card-th.tsx
+++ b/packages/wiz-ui-react/src/components/base/tables/card/components/card-th.tsx
@@ -2,16 +2,25 @@ import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
 import * as styles from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
 import { ComponentProps, ReactNode } from "react";
 
+import { useIsSafari } from "../hooks/use-is-safari";
+
 type Props = {
   width?: string;
   children?: ReactNode;
 } & ComponentProps<"th">;
 
-const CardTh = ({ width = "auto", children, ...props }: Props) => (
-  <th className={styles.cardThStyle} style={{ width }} {...props}>
-    {children}
-  </th>
-);
+const CardTh = ({ width = "auto", children, ...props }: Props) => {
+  const isSafari = useIsSafari();
+  return (
+    <th
+      className={isSafari ? styles.cardThOnSafariStyle : styles.cardThStyle}
+      style={{ width }}
+      {...props}
+    >
+      {children}
+    </th>
+  );
+};
 
 CardTh.displayName = ComponentName.CardTh;
 

--- a/packages/wiz-ui-react/src/components/base/tables/card/components/card-tr.tsx
+++ b/packages/wiz-ui-react/src/components/base/tables/card/components/card-tr.tsx
@@ -2,15 +2,23 @@ import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
 import * as styles from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
 import { ComponentProps, ReactNode } from "react";
 
+import { useIsSafari } from "../hooks/use-is-safari";
+
 type Props = {
   children?: ReactNode;
 } & ComponentProps<"tr">;
 
-const CardTr = ({ children, ...props }: Props) => (
-  <tr className={styles.cardTrStyle} {...props}>
-    {children}
-  </tr>
-);
+const CardTr = ({ children, ...props }: Props) => {
+  const isSafari = useIsSafari();
+  return (
+    <tr
+      className={isSafari ? styles.cardTrOnSafariStyle : styles.cardTrStyle}
+      {...props}
+    >
+      {children}
+    </tr>
+  );
+};
 
 CardTr.displayName = ComponentName.CardTr;
 

--- a/packages/wiz-ui-react/src/components/base/tables/card/hooks/use-is-safari.ts
+++ b/packages/wiz-ui-react/src/components/base/tables/card/hooks/use-is-safari.ts
@@ -1,0 +1,4 @@
+export const useIsSafari = () => {
+  const ua = navigator.userAgent.toLowerCase();
+  return ua.indexOf("safari") !== -1 && ua.indexOf("chrome") === -1;
+};

--- a/packages/wiz-ui/src/components/base/tables/card/hooks/use-is-safari.ts
+++ b/packages/wiz-ui/src/components/base/tables/card/hooks/use-is-safari.ts
@@ -1,0 +1,4 @@
+export const useIsSafari = () => {
+  const ua = navigator.userAgent.toLowerCase();
+  return ua.indexOf("safari") !== -1 && ua.indexOf("chrome") === -1;
+};

--- a/packages/wiz-ui/src/components/base/tables/card/table.vue
+++ b/packages/wiz-ui/src/components/base/tables/card/table.vue
@@ -1,6 +1,9 @@
 <template>
   <table
-    :class="[cardTableStyle, fixed && cardTableFixedStyle]"
+    :class="[
+      isSafari ? cardTableOnSafariStyle : cardTableStyle,
+      fixed && cardTableFixedStyle,
+    ]"
     :style="{ width }"
   >
     <slot />
@@ -12,7 +15,10 @@ import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
 import {
   cardTableStyle,
   cardTableFixedStyle,
+  cardTableOnSafariStyle,
 } from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
+
+import { useIsSafari } from "./hooks/use-is-safari";
 
 defineOptions({
   name: ComponentName.CardTable,
@@ -29,4 +35,6 @@ defineProps({
     required: false,
   },
 });
+
+const isSafari = useIsSafari();
 </script>

--- a/packages/wiz-ui/src/components/base/tables/card/table.vue
+++ b/packages/wiz-ui/src/components/base/tables/card/table.vue
@@ -1,8 +1,8 @@
 <template>
   <table
     :class="[
-      isSafari ? cardTableOnSafariStyle : cardTableStyle,
-      fixed && cardTableFixedStyle,
+      isSafari ? styles.cardTableOnSafariStyle : styles.cardTableStyle,
+      fixed && styles.cardTableFixedStyle,
     ]"
     :style="{ width }"
   >
@@ -12,11 +12,7 @@
 
 <script setup lang="ts">
 import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
-import {
-  cardTableStyle,
-  cardTableFixedStyle,
-  cardTableOnSafariStyle,
-} from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
+import * as styles from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
 
 import { useIsSafari } from "./hooks/use-is-safari";
 

--- a/packages/wiz-ui/src/components/base/tables/card/td.vue
+++ b/packages/wiz-ui/src/components/base/tables/card/td.vue
@@ -1,12 +1,21 @@
 <template>
-  <td :class="cardTdStyle" :rowSpan="rowSpan" :colSpan="colSpan">
+  <td
+    :class="isSafari ? cardTdOnSafariStyle : cardTdStyle"
+    :rowSpan="rowSpan"
+    :colSpan="colSpan"
+  >
     <slot />
   </td>
 </template>
 
 <script setup lang="ts">
 import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
-import { cardTdStyle } from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
+import {
+  cardTdStyle,
+  cardTdOnSafariStyle,
+} from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
+
+import { useIsSafari } from "./hooks/use-is-safari";
 
 defineOptions({
   name: ComponentName.CardTd,
@@ -22,4 +31,6 @@ defineProps({
     required: false,
   },
 });
+
+const isSafari = useIsSafari();
 </script>

--- a/packages/wiz-ui/src/components/base/tables/card/td.vue
+++ b/packages/wiz-ui/src/components/base/tables/card/td.vue
@@ -1,6 +1,6 @@
 <template>
   <td
-    :class="isSafari ? cardTdOnSafariStyle : cardTdStyle"
+    :class="isSafari ? styles.cardTdOnSafariStyle : styles.cardTdStyle"
     :rowSpan="rowSpan"
     :colSpan="colSpan"
   >
@@ -10,10 +10,7 @@
 
 <script setup lang="ts">
 import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
-import {
-  cardTdStyle,
-  cardTdOnSafariStyle,
-} from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
+import * as styles from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
 
 import { useIsSafari } from "./hooks/use-is-safari";
 

--- a/packages/wiz-ui/src/components/base/tables/card/th.vue
+++ b/packages/wiz-ui/src/components/base/tables/card/th.vue
@@ -1,6 +1,6 @@
 <template>
   <th
-    :class="isSafari ? cardThOnSafariStyle : cardThStyle"
+    :class="isSafari ? styles.cardThOnSafariStyle : styles.cardThStyle"
     :style="{ width }"
     :rowSpan="rowSpan"
     :colSpan="colSpan"
@@ -11,10 +11,7 @@
 
 <script setup lang="ts">
 import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
-import {
-  cardThStyle,
-  cardThOnSafariStyle,
-} from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
+import * as styles from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
 
 import { useIsSafari } from "./hooks/use-is-safari";
 

--- a/packages/wiz-ui/src/components/base/tables/card/th.vue
+++ b/packages/wiz-ui/src/components/base/tables/card/th.vue
@@ -1,6 +1,6 @@
 <template>
   <th
-    :class="cardThStyle"
+    :class="isSafari ? cardThOnSafariStyle : cardThStyle"
     :style="{ width }"
     :rowSpan="rowSpan"
     :colSpan="colSpan"
@@ -11,7 +11,12 @@
 
 <script setup lang="ts">
 import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
-import { cardThStyle } from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
+import {
+  cardThStyle,
+  cardThOnSafariStyle,
+} from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
+
+import { useIsSafari } from "./hooks/use-is-safari";
 
 defineOptions({
   name: ComponentName.CardTh,
@@ -32,4 +37,6 @@ defineProps({
     required: false,
   },
 });
+
+const isSafari = useIsSafari();
 </script>

--- a/packages/wiz-ui/src/components/base/tables/card/tr.vue
+++ b/packages/wiz-ui/src/components/base/tables/card/tr.vue
@@ -1,12 +1,16 @@
 <template>
-  <tr :class="cardTrStyle" @click="onClick">
+  <tr :class="[isSafari ? cardTrOnSafariStyle : cardTrStyle]" @click="onClick">
     <slot />
   </tr>
 </template>
 
 <script setup lang="ts">
 import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
-import { cardTrStyle } from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
+import {
+  cardTrStyle,
+  cardTrOnSafariStyle,
+} from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
+import { computed } from "vue";
 
 defineOptions({
   name: ComponentName.CardTr,
@@ -19,4 +23,9 @@ interface Emits {
 const emits = defineEmits<Emits>();
 
 const onClick = () => emits("click");
+
+const isSafari = computed(() => {
+  const ua = navigator.userAgent.toLowerCase();
+  return ua.indexOf("safari") !== -1 && ua.indexOf("chrome") === -1;
+});
 </script>

--- a/packages/wiz-ui/src/components/base/tables/card/tr.vue
+++ b/packages/wiz-ui/src/components/base/tables/card/tr.vue
@@ -10,7 +10,8 @@ import {
   cardTrStyle,
   cardTrOnSafariStyle,
 } from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
-import { computed } from "vue";
+
+import { useIsSafari } from "./hooks/use-is-safari";
 
 defineOptions({
   name: ComponentName.CardTr,
@@ -24,8 +25,5 @@ const emits = defineEmits<Emits>();
 
 const onClick = () => emits("click");
 
-const isSafari = computed(() => {
-  const ua = navigator.userAgent.toLowerCase();
-  return ua.indexOf("safari") !== -1 && ua.indexOf("chrome") === -1;
-});
+const isSafari = useIsSafari();
 </script>

--- a/packages/wiz-ui/src/components/base/tables/card/tr.vue
+++ b/packages/wiz-ui/src/components/base/tables/card/tr.vue
@@ -1,15 +1,15 @@
 <template>
-  <tr :class="[isSafari ? cardTrOnSafariStyle : cardTrStyle]" @click="onClick">
+  <tr
+    :class="[isSafari ? styles.cardTrOnSafariStyle : styles.cardTrStyle]"
+    @click="onClick"
+  >
     <slot />
   </tr>
 </template>
 
 <script setup lang="ts">
 import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
-import {
-  cardTrStyle,
-  cardTrOnSafariStyle,
-} from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
+import * as styles from "@wizleap-inc/wiz-ui-styles/bases/card-table.css";
 
 import { useIsSafari } from "./hooks/use-is-safari";
 


### PR DESCRIPTION
# タスク

resolve: #617

## 修正内容
- Safari 用に :hover 時の td, tr タグの CSS を追加した。
- Safari での hover 時の border を outline で表示するようにした

## 課題点
- テーブル外でも hover が効いてしまうバグがのこっていること 
- Safari での border の出し方を変えてしまっているためこれでいいかどうかの確認が必要なこと

## 動作の様子

https://github.com/Wizleap-Inc/wiz-ui/assets/29594820/88174cab-c53f-4e63-ac62-3bef3f51879f


## 参考

- Safari では、tr タグ要素に :after といった疑似要素が適用できないようです。

![スクリーンショット 2023-08-15 22 50 42](https://github.com/Wizleap-Inc/wiz-ui/assets/29594820/2340c2ca-9097-470b-adce-c295ec9f977a)


