### PR TITLE
Feat: フォームに関連するコンポーネントの高さを44pxに統一

### DIFF
--- a/.changeset/early-apples-eat.md
+++ b/.changeset/early-apples-eat.md
@@ -1,0 +1,5 @@
+---
+"@wizleap-inc/wiz-ui-styles": minor
+---
+
+adjust height of components related to form to 44px

--- a/packages/styles/bases/base-input.css.ts
+++ b/packages/styles/bases/base-input.css.ts
@@ -4,7 +4,7 @@ import { THEME } from "@wizleap-inc/wiz-ui-constants";
 export const baseInputStyle = style({
   borderRadius: THEME.spacing.xs2,
   fontSize: THEME.fontSize.sm,
-  lineHeight: 1.5,
+  lineHeight: 1.86,
   color: THEME.color.gray[700],
   boxSizing: "border-box",
 

--- a/packages/styles/bases/base-input.css.ts
+++ b/packages/styles/bases/base-input.css.ts
@@ -4,7 +4,7 @@ import { THEME } from "@wizleap-inc/wiz-ui-constants";
 export const baseInputStyle = style({
   borderRadius: THEME.spacing.xs2,
   fontSize: THEME.fontSize.sm,
-  lineHeight: 1.86,
+  lineHeight: THEME.fontSize.lg,
   color: THEME.color.gray[700],
   boxSizing: "border-box",
 
@@ -19,18 +19,18 @@ export const baseInputStyle = style({
 
 export const baseInputPaddingStyle = styleVariants({
   left: {
-    padding: `${THEME.spacing.xs} ${THEME.spacing.md}`,
+    padding: `${THEME.spacing.sm} ${THEME.spacing.md}`,
     paddingLeft: THEME.spacing.xl3,
   },
   right: {
-    padding: `${THEME.spacing.xs} ${THEME.spacing.md}`,
+    padding: `${THEME.spacing.sm} ${THEME.spacing.md}`,
     paddingRight: THEME.spacing.xl3,
   },
   both: {
-    padding: `${THEME.spacing.xs} ${THEME.spacing.md}`,
+    padding: `${THEME.spacing.sm} ${THEME.spacing.md}`,
   },
   none: {
-    padding: `${THEME.spacing.xs} ${THEME.spacing.md}`,
+    padding: `${THEME.spacing.sm} ${THEME.spacing.md}`,
   },
 });
 

--- a/packages/styles/bases/date-picker-input.css.ts
+++ b/packages/styles/bases/date-picker-input.css.ts
@@ -1,11 +1,13 @@
 import { style, styleVariants } from "@vanilla-extract/css";
 import { THEME } from "@wizleap-inc/wiz-ui-constants";
 
+const BORDER_WIDTH = "1px";
+
 export const datePickerStyle = style({
   width: "max-content",
   borderRadius: THEME.spacing.xs2,
   boxSizing: "border-box",
-  padding: `${THEME.spacing.xs} ${THEME.spacing.xs}`,
+  padding: `calc(${THEME.spacing.xs} - ${BORDER_WIDTH}) ${THEME.spacing.xs}`,
   fontSize: THEME.fontSize.sm,
   lineHeight: THEME.fontSize.xl3,
 });

--- a/packages/styles/bases/date-picker-input.css.ts
+++ b/packages/styles/bases/date-picker-input.css.ts
@@ -3,11 +3,11 @@ import { THEME } from "@wizleap-inc/wiz-ui-constants";
 
 export const datePickerStyle = style({
   width: "max-content",
-  height: THEME.spacing.xl3,
   borderRadius: THEME.spacing.xs2,
   boxSizing: "border-box",
-  padding: `${THEME.spacing.no} ${THEME.spacing.xs}`,
+  padding: `${THEME.spacing.xs} ${THEME.spacing.xs}`,
   fontSize: THEME.fontSize.sm,
+  lineHeight: THEME.fontSize.xl3,
 });
 
 export const datePickerVariantStyle = styleVariants({

--- a/packages/styles/bases/date-range-picker.css.ts
+++ b/packages/styles/bases/date-range-picker.css.ts
@@ -1,10 +1,12 @@
 import { style, styleVariants } from "@vanilla-extract/css";
 import { THEME } from "@wizleap-inc/wiz-ui-constants";
 
+const BORDER_WIDTH = "1px";
+
 const baseBodyStyle = style({
   borderRadius: THEME.spacing.xs2,
   boxSizing: "border-box",
-  padding: `${THEME.spacing.xs} ${THEME.spacing.xs}`,
+  padding: `calc(${THEME.spacing.xs} - ${BORDER_WIDTH}) ${THEME.spacing.xs}`,
   fontSize: THEME.fontSize.sm,
   display: "flex",
   alignItems: "center",

--- a/packages/styles/bases/date-range-picker.css.ts
+++ b/packages/styles/bases/date-range-picker.css.ts
@@ -2,10 +2,9 @@ import { style, styleVariants } from "@vanilla-extract/css";
 import { THEME } from "@wizleap-inc/wiz-ui-constants";
 
 const baseBodyStyle = style({
-  height: THEME.spacing.xl3,
   borderRadius: THEME.spacing.xs2,
   boxSizing: "border-box",
-  padding: `${THEME.spacing.no} ${THEME.spacing.xs}`,
+  padding: `${THEME.spacing.xs} ${THEME.spacing.xs}`,
   fontSize: THEME.fontSize.sm,
   display: "flex",
   alignItems: "center",
@@ -45,6 +44,7 @@ export const separatorStyle = style({
 const inputTextBaseStyle = style({
   fontSize: THEME.fontSize.sm,
   width: "100%",
+  lineHeight: THEME.fontSize.xl3,
 });
 
 export const inputTextStyle = styleVariants({

--- a/packages/styles/bases/search-input.css.ts
+++ b/packages/styles/bases/search-input.css.ts
@@ -7,11 +7,13 @@ export const searchStyle = style({
   position: "relative",
 });
 
+const BORDER_WIDTH = "1px";
+
 export const searchInputStyle = style({
   borderRadius: THEME.spacing.xs2,
-  padding: `${THEME.spacing.xs} ${THEME.spacing.xl2} ${THEME.spacing.xs} ${THEME.spacing.xl3}`,
+  padding: `calc(${THEME.spacing.sm} - ${BORDER_WIDTH}) ${THEME.spacing.xl2} calc(${THEME.spacing.sm} - ${BORDER_WIDTH}) ${THEME.spacing.xl3}`,
   fontSize: THEME.fontSize.sm,
-  lineHeight: THEME.spacing.xl,
+  lineHeight: THEME.spacing.lg,
   color: THEME.color.gray[700],
   boxSizing: "border-box",
   ":focus": {
@@ -30,7 +32,8 @@ export const searchInputDisabledStyle = style({
 
 export const searchInputIconStyle = style({
   position: "absolute",
-  top: THEME.spacing.xs,
+  top: "50%",
+  transform: "translateY(-50%)",
   left: THEME.spacing.xs,
   display: "flex",
   alignItems: "center",

--- a/packages/styles/bases/search-selector.css.ts
+++ b/packages/styles/bases/search-selector.css.ts
@@ -124,12 +124,15 @@ export const selectBoxSelectorOptionLabelStyle = style({
   whiteSpace: "nowrap",
 });
 
+const BORDER_WIDTH = "1px";
+
 export const selectBoxSearchInputStyle = style({
   width: 0,
   minWidth: "30%",
   border: "none",
   outline: "none",
-  padding: `${THEME.spacing.xs2} ${THEME.spacing.no}`,
+  padding: `calc(${THEME.spacing.xs2} - ${BORDER_WIDTH}) ${THEME.spacing.no}`,
+  lineHeight: THEME.fontSize.xl,
   flexGrow: 1,
   fontSize: THEME.fontSize.sm,
   color: THEME.color.gray["500"],

--- a/packages/styles/bases/selectbox-input.css.ts
+++ b/packages/styles/bases/selectbox-input.css.ts
@@ -3,7 +3,6 @@ import { THEME } from "@wizleap-inc/wiz-ui-constants";
 
 export const selectBoxStyle = style({
   position: "relative",
-  height: THEME.spacing.xl3,
   background: THEME.color.white["800"],
   borderRadius: THEME.spacing.xs2,
   boxSizing: "border-box",
@@ -25,11 +24,12 @@ export const selectBoxCursorStyle = styleVariants({
 
 export const selectBoxInnerBoxStyle = style({
   height: "100%",
-  padding: `${THEME.spacing.no} ${THEME.spacing.xs}`,
+  padding: `${THEME.spacing.xs} ${THEME.spacing.xs}`,
   fontSize: THEME.fontSize.sm,
   color: THEME.color.gray["500"],
   width: "100%",
   boxSizing: "border-box",
+  lineHeight: THEME.fontSize.xl3,
 });
 
 export const selectBoxInnerBoxSelectedValueStyle = style({

--- a/packages/styles/bases/selectbox-input.css.ts
+++ b/packages/styles/bases/selectbox-input.css.ts
@@ -22,9 +22,11 @@ export const selectBoxCursorStyle = styleVariants({
   },
 });
 
+const BORDER_WIDTH = "1px";
+
 export const selectBoxInnerBoxStyle = style({
   height: "100%",
-  padding: `${THEME.spacing.xs} ${THEME.spacing.xs}`,
+  padding: `calc(${THEME.spacing.xs} - ${BORDER_WIDTH}) ${THEME.spacing.xs}`,
   fontSize: THEME.fontSize.sm,
   color: THEME.color.gray["500"],
   width: "100%",

--- a/packages/styles/bases/text-button.css.ts
+++ b/packages/styles/bases/text-button.css.ts
@@ -71,18 +71,21 @@ export const textButtonSizeStyle = styleVariants({
     textButtonSizeNotXsStyle,
     {
       fontSize: THEME.fontSize.xs,
+      lineHeight: THEME.fontSize.xl,
     },
   ],
   md: [
     textButtonSizeNotXsStyle,
     {
       fontSize: THEME.fontSize.sm,
+      lineHeight: THEME.fontSize.xl2,
     },
   ],
   lg: [
     textButtonSizeNotXsStyle,
     {
       fontSize: THEME.fontSize.md,
+      lineHeight: THEME.fontSize.xl3,
     },
   ],
 });

--- a/packages/styles/bases/time-picker-input.css.ts
+++ b/packages/styles/bases/time-picker-input.css.ts
@@ -4,7 +4,6 @@ import { THEME } from "@wizleap-inc/wiz-ui-constants";
 export const timePickerStyle = style({
   width: "max-content",
   padding: `0 ${THEME.spacing.xs2}`,
-  height: THEME.spacing.xl3,
   background: THEME.color.white["800"],
   borderRadius: THEME.spacing.xs2,
   boxSizing: "border-box",
@@ -26,8 +25,9 @@ export const timePickerCursorStyle = styleVariants({
 
 export const timePickerBoxStyle = style({
   height: "100%",
-  padding: `${THEME.spacing.no} ${THEME.spacing.xs}`,
+  padding: `${THEME.spacing.xs} ${THEME.spacing.xs}`,
   fontSize: THEME.fontSize.sm,
+  lineHeight: THEME.fontSize.xl3,
 });
 
 export const timePickerBoxColorStyle = styleVariants({

--- a/packages/styles/bases/time-picker-input.css.ts
+++ b/packages/styles/bases/time-picker-input.css.ts
@@ -23,9 +23,11 @@ export const timePickerCursorStyle = styleVariants({
   },
 });
 
+const BORDER_WIDTH = "1px";
+
 export const timePickerBoxStyle = style({
   height: "100%",
-  padding: `${THEME.spacing.xs} ${THEME.spacing.xs}`,
+  padding: `calc(${THEME.spacing.xs} - ${BORDER_WIDTH}) ${THEME.spacing.xs}`,
   fontSize: THEME.fontSize.sm,
   lineHeight: THEME.fontSize.xl3,
 });

--- a/packages/styles/bases/toggle-button.css.ts
+++ b/packages/styles/bases/toggle-button.css.ts
@@ -10,7 +10,6 @@ export const toggleButtonStyle = style({
   border: "none",
   fontWeight: "bold",
   padding: `${THEME.spacing.xs} ${THEME.spacing.md}`,
-  lineHeight: THEME.fontSize.xl3,
   borderRadius: THEME.spacing.xs2,
   background: THEME.color.white[800],
   boxShadow: THEME.shadow.sm,

--- a/packages/styles/bases/toggle-button.css.ts
+++ b/packages/styles/bases/toggle-button.css.ts
@@ -10,6 +10,7 @@ export const toggleButtonStyle = style({
   border: "none",
   fontWeight: "bold",
   padding: `${THEME.spacing.xs} ${THEME.spacing.md}`,
+  lineHeight: THEME.fontSize.xl3,
   borderRadius: THEME.spacing.xs2,
   background: THEME.color.white[800],
   boxShadow: THEME.shadow.sm,


### PR DESCRIPTION
# タスク

resolve: #712

フォームに関連するコンポーネントの高さを44pxに統一しました。

### 高さを44pxに統一
* text-input
* password-input
* select-box
* date-picker
* date-range-picker
* time-picker
* search-selector
* search

### button-textとbutton-toggleのサイズ毎の高さを統一
sm: 36px
md: 40px
lg: 44px
※ https://github.com/Wizleap-Inc/wiz-ui/issues/772 のissueをこちらのPRにまとめました。

