### PR TITLE
Feat: グローバルナビとサブメニューの高さを44pxにする

### DIFF
--- a/.changeset/sixty-grapes-retire.md
+++ b/.changeset/sixty-grapes-retire.md
@@ -1,0 +1,5 @@
+---
+"@wizleap-inc/wiz-ui-styles": minor
+---
+
+adjust menu-item and navigation-item height to 44px

--- a/packages/styles/bases/menu.css.ts
+++ b/packages/styles/bases/menu.css.ts
@@ -3,6 +3,7 @@ import { THEME } from "@wizleap-inc/wiz-ui-constants";
 
 export const menuItemStyle = style({
   padding: `${THEME.spacing.xs} ${THEME.spacing.md}`,
+  lineHeight: THEME.fontSize.xl3,
 });
 
 export const menuItemVariantStyle = styleVariants({

--- a/packages/styles/bases/navigation.css.ts
+++ b/packages/styles/bases/navigation.css.ts
@@ -33,7 +33,7 @@ export const navigationItemStyle = style({
   textDecoration: "none",
   position: "relative",
   fontSize: THEME.fontSize.xs,
-  lineHeight: THEME.fontSize.xl2,
+  lineHeight: THEME.fontSize.xl3,
   transition: "background-color 0.2s ease-in-out",
   ":before": {
     content: '""',


### PR DESCRIPTION
# タスク

resolve: #677

グローバルナビとサブメニューの高さを44pxにしました。

対象コンポーネント
* navigation-item http://localhost:6007/?path=/docs/base-navigation-item--docs
* menu-item http://localhost:6007/?path=/docs/base-menuitem--docs
