### PR TITLE
Feat: WizFormGroupでラベルのサイズと色を一括指定できるようにする

### DIFF
--- a/.changeset/shiny-apricots-complain.md
+++ b/.changeset/shiny-apricots-complain.md
@@ -1,0 +1,6 @@
+---
+"@wizleap-inc/wiz-ui-next": minor
+"@wizleap-inc/wiz-ui": minor
+---
+
+WizFormGroup でラベルのサイズと色を一括指定できるようにする

--- a/packages/wiz-ui-next/src/components/custom/form/control.vue
+++ b/packages/wiz-ui-next/src/components/custom/form/control.vue
@@ -2,7 +2,13 @@
   <WizVStack>
     <WizHStack>
       <WizHStack :width="labelWidth" align="center" gap="xs2">
-        <WizText as="label" :htmlFor="htmlFor">{{ label }}</WizText>
+        <WizText
+          as="label"
+          :htmlFor="htmlFor"
+          :color="labelColor"
+          :font-size="labelFontSize"
+          >{{ label }}</WizText
+        >
         <WizTag font-size="xs2" label="必須" v-if="required" />
       </WizHStack>
       <WizVStack>
@@ -57,6 +63,8 @@ const props = defineProps({
 // Form Group
 const fromGroup = inject(formGroupKey);
 const labelWidth = computed(() => fromGroup?.labelWidth.value || "8rem");
+const labelColor = computed(() => fromGroup?.labelColor.value || "gray.900");
+const labelFontSize = computed(() => fromGroup?.labelFontSize.value || "md");
 
 // Form Control
 const provider = useFormControlProvider();

--- a/packages/wiz-ui-next/src/components/custom/form/group.stories.ts
+++ b/packages/wiz-ui-next/src/components/custom/form/group.stories.ts
@@ -1,5 +1,11 @@
 import { Meta, StoryFn } from "@storybook/vue3";
-import { ColorKeys, FontSizeKeys } from "@wizleap-inc/wiz-ui-constants";
+import {
+  COLOR_MAP_ACCESSORS,
+  ColorKeys,
+  FONT_SIZE_ACCESSORS,
+  FontSizeKeys,
+  SPACING_ACCESSORS,
+} from "@wizleap-inc/wiz-ui-constants";
 import { ref } from "vue";
 
 import {
@@ -27,7 +33,23 @@ export default {
   title: "Custom/Form/Group",
   component: WizFormGroup,
   subcomponents: { WizFormControl },
-  argTypes: {},
+  argTypes: {
+    labelWidth: {
+      control: { type: "text" },
+    },
+    gap: {
+      control: { type: "select" },
+      options: SPACING_ACCESSORS,
+    },
+    labelColor: {
+      control: { type: "select" },
+      options: COLOR_MAP_ACCESSORS,
+    },
+    labelFontSize: {
+      control: { type: "select" },
+      options: FONT_SIZE_ACCESSORS,
+    },
+  },
 } as Meta<typeof WizFormGroup>;
 
 const Template: StoryFn<typeof WizFormGroup> = (args) => ({

--- a/packages/wiz-ui-next/src/components/custom/form/group.stories.ts
+++ b/packages/wiz-ui-next/src/components/custom/form/group.stories.ts
@@ -1,5 +1,5 @@
 import { Meta, StoryFn } from "@storybook/vue3";
-import { SPACING_ACCESSORS } from "@wizleap-inc/wiz-ui-constants";
+import { ColorKeys, FontSizeKeys } from "@wizleap-inc/wiz-ui-constants";
 import { ref } from "vue";
 
 import {
@@ -27,15 +27,7 @@ export default {
   title: "Custom/Form/Group",
   component: WizFormGroup,
   subcomponents: { WizFormControl },
-  argTypes: {
-    labelWidth: {
-      control: { type: "text" },
-    },
-    gap: {
-      control: { type: "select" },
-      options: SPACING_ACCESSORS,
-    },
-  },
+  argTypes: {},
 } as Meta<typeof WizFormGroup>;
 
 const Template: StoryFn<typeof WizFormGroup> = (args) => ({
@@ -60,13 +52,22 @@ const Template: StoryFn<typeof WizFormGroup> = (args) => ({
 interface Options {
   labelWidth: string;
   gap: string;
+  labelColor: ColorKeys;
+  labelFontSize: FontSizeKeys;
 }
 
-const CODE_TEMPLATE = ({ labelWidth, gap }: Partial<Options>) => `
+const CODE_TEMPLATE = ({
+  labelWidth,
+  gap,
+  labelColor,
+  labelFontSize,
+}: Partial<Options>) => `
 <template>
   <WizFormGroup${
     (labelWidth ? ` label-width="${labelWidth}"` : "") +
-    (gap ? ` gap="${gap}"` : "")
+    (gap ? ` gap="${gap}"` : "") +
+    (labelColor ? ` label-color="${labelColor}"` : "") +
+    (labelFontSize ? ` label-font-size="${labelFontSize}"` : "")
   }>
     <WizFormControl label="Label1">
       <WizTextInput v-model="input" name="input" />
@@ -128,6 +129,38 @@ Gap.parameters = {
     },
     source: {
       code: CODE_TEMPLATE({ gap: "md" }),
+    },
+  },
+};
+
+export const LabelColor = Template.bind({});
+LabelColor.args = {
+  labelColor: "red.500",
+};
+LabelColor.parameters = {
+  docs: {
+    description: {
+      story:
+        "slotに持っている**FormControl**の各要素のラベル色を一括指定できます。",
+    },
+    source: {
+      code: CODE_TEMPLATE({ labelColor: "red.500" }),
+    },
+  },
+};
+
+export const LabelFontSize = Template.bind({});
+LabelFontSize.args = {
+  labelFontSize: "xl3",
+};
+LabelFontSize.parameters = {
+  docs: {
+    description: {
+      story:
+        "slotに持っている**FormControl**の各要素のラベルサイズを一括指定できます。",
+    },
+    source: {
+      code: CODE_TEMPLATE({ labelFontSize: "xl3" }),
     },
   },
 };

--- a/packages/wiz-ui-next/src/components/custom/form/group.vue
+++ b/packages/wiz-ui-next/src/components/custom/form/group.vue
@@ -5,7 +5,11 @@
 </template>
 
 <script setup lang="ts">
-import { SpacingKeys } from "@wizleap-inc/wiz-ui-constants";
+import {
+  ColorKeys,
+  FontSizeKeys,
+  SpacingKeys,
+} from "@wizleap-inc/wiz-ui-constants";
 import { onMounted, provide, watch, PropType } from "vue";
 
 import { WizVStack } from "@/components/base";
@@ -23,12 +27,24 @@ const props = defineProps({
     type: String as PropType<SpacingKeys>,
     required: false,
   },
+  labelColor: {
+    type: String as PropType<ColorKeys>,
+    required: false,
+  },
+  labelFontSize: {
+    type: String as PropType<FontSizeKeys>,
+    required: false,
+  },
 });
 
 // Form Group
 const provider = useFormGroupProvider();
 provide(formGroupKey, provider);
-const { setLabelWidth } = provider;
+const { setLabelWidth, setLabelColor, setLabelFontSize } = provider;
 watch(props, (p) => p.labelWidth && setLabelWidth(p.labelWidth));
 onMounted(() => props.labelWidth && setLabelWidth(props.labelWidth));
+watch(props, (p) => p.labelColor && setLabelColor(p.labelColor));
+onMounted(() => props.labelColor && setLabelColor(props.labelColor));
+watch(props, (p) => p.labelFontSize && setLabelFontSize(p.labelFontSize));
+onMounted(() => props.labelFontSize && setLabelFontSize(props.labelFontSize));
 </script>

--- a/packages/wiz-ui-next/src/hooks/use-form-group-provider.ts
+++ b/packages/wiz-ui-next/src/hooks/use-form-group-provider.ts
@@ -1,3 +1,4 @@
+import { ColorKeys, FontSizeKeys } from "@wizleap-inc/wiz-ui-constants";
 import { ref, readonly, InjectionKey } from "vue";
 
 export const useFormGroupProvider = () => {
@@ -6,9 +7,23 @@ export const useFormGroupProvider = () => {
     labelWidth.value = value;
   };
 
+  const labelColor = ref<ColorKeys>("gray.900");
+  const setLabelColor = (value: ColorKeys) => {
+    labelColor.value = value;
+  };
+
+  const labelFontSize = ref<FontSizeKeys>("md");
+  const setLabelFontSize = (value: FontSizeKeys) => {
+    labelFontSize.value = value;
+  };
+
   return {
     labelWidth: readonly(labelWidth),
     setLabelWidth,
+    labelColor: readonly(labelColor),
+    setLabelColor,
+    labelFontSize: readonly(labelFontSize),
+    setLabelFontSize,
   };
 };
 

--- a/packages/wiz-ui/src/components/custom/form/control.vue
+++ b/packages/wiz-ui/src/components/custom/form/control.vue
@@ -2,7 +2,13 @@
   <WizVStack>
     <WizHStack>
       <WizHStack :width="labelWidth" align="center" gap="xs2">
-        <WizText as="label" :htmlFor="htmlFor">{{ label }}</WizText>
+        <WizText
+          as="label"
+          :htmlFor="htmlFor"
+          :color="labelColor"
+          :font-size="labelFontSize"
+          >{{ label }}</WizText
+        >
         <WizTag font-size="xs2" label="必須" v-if="required" />
       </WizHStack>
       <WizVStack>
@@ -57,6 +63,8 @@ const props = defineProps({
 // Form Group
 const fromGroup = inject(formGroupKey);
 const labelWidth = computed(() => fromGroup?.labelWidth.value || "8rem");
+const labelColor = computed(() => fromGroup?.labelColor.value || "gray.900");
+const labelFontSize = computed(() => fromGroup?.labelFontSize.value || "md");
 
 // Form Control
 const provider = useFormControlProvider();

--- a/packages/wiz-ui/src/components/custom/form/group.stories.ts
+++ b/packages/wiz-ui/src/components/custom/form/group.stories.ts
@@ -1,5 +1,9 @@
 import { StoryFn } from "@storybook/vue";
-import { SPACING_ACCESSORS } from "@wizleap-inc/wiz-ui-constants";
+import {
+  ColorKeys,
+  FontSizeKeys,
+  SPACING_ACCESSORS,
+} from "@wizleap-inc/wiz-ui-constants";
 import { ref } from "vue";
 
 import {
@@ -61,13 +65,22 @@ const Template: StoryFn = (_, { argTypes }) => ({
 interface Options {
   labelWidth: string;
   gap: string;
+  labelColor: ColorKeys;
+  labelFontSize: FontSizeKeys;
 }
 
-const CODE_TEMPLATE = ({ labelWidth, gap }: Partial<Options>) => `
+const CODE_TEMPLATE = ({
+  labelWidth,
+  gap,
+  labelColor,
+  labelFontSize,
+}: Partial<Options>) => `
 <template>
   <WizFormGroup${
     (labelWidth ? ` label-width="${labelWidth}"` : "") +
-    (gap ? ` gap="${gap}"` : "")
+    (gap ? ` gap="${gap}"` : "") +
+    (labelColor ? ` label-color="${labelColor}"` : "") +
+    (labelFontSize ? ` label-font-size="${labelFontSize}"` : "")
   }>
     <WizFormControl label="Label1">
       <WizTextInput v-model="input" name="input" />
@@ -129,6 +142,38 @@ Gap.parameters = {
     },
     source: {
       code: CODE_TEMPLATE({ gap: "md" }),
+    },
+  },
+};
+
+export const LabelColor = Template.bind({});
+LabelColor.args = {
+  labelColor: "red.500",
+};
+LabelColor.parameters = {
+  docs: {
+    description: {
+      story:
+        "slotに持っている**FormControl**の各要素のラベル色を一括指定できます。",
+    },
+    source: {
+      code: CODE_TEMPLATE({ labelColor: "red.500" }),
+    },
+  },
+};
+
+export const LabelFontSize = Template.bind({});
+LabelFontSize.args = {
+  labelFontSize: "xl3",
+};
+LabelFontSize.parameters = {
+  docs: {
+    description: {
+      story:
+        "slotに持っている**FormControl**の各要素のラベルサイズを一括指定できます。",
+    },
+    source: {
+      code: CODE_TEMPLATE({ labelFontSize: "xl3" }),
     },
   },
 };

--- a/packages/wiz-ui/src/components/custom/form/group.stories.ts
+++ b/packages/wiz-ui/src/components/custom/form/group.stories.ts
@@ -1,6 +1,8 @@
 import { StoryFn } from "@storybook/vue";
 import {
+  COLOR_MAP_ACCESSORS,
   ColorKeys,
+  FONT_SIZE_ACCESSORS,
   FontSizeKeys,
   SPACING_ACCESSORS,
 } from "@wizleap-inc/wiz-ui-constants";
@@ -38,6 +40,14 @@ export default {
     gap: {
       control: { type: "select" },
       options: SPACING_ACCESSORS,
+    },
+    labelColor: {
+      control: { type: "select" },
+      options: COLOR_MAP_ACCESSORS,
+    },
+    labelFontSize: {
+      control: { type: "select" },
+      options: FONT_SIZE_ACCESSORS,
     },
   },
 };

--- a/packages/wiz-ui/src/components/custom/form/group.vue
+++ b/packages/wiz-ui/src/components/custom/form/group.vue
@@ -5,7 +5,11 @@
 </template>
 
 <script setup lang="ts">
-import { SpacingKeys } from "@wizleap-inc/wiz-ui-constants";
+import {
+  ColorKeys,
+  FontSizeKeys,
+  SpacingKeys,
+} from "@wizleap-inc/wiz-ui-constants";
 import { onMounted, provide, watch, PropType } from "vue";
 
 import { WizVStack } from "@/components/base";
@@ -23,12 +27,24 @@ const props = defineProps({
     type: String as PropType<SpacingKeys>,
     required: false,
   },
+  labelColor: {
+    type: String as PropType<ColorKeys>,
+    required: false,
+  },
+  labelFontSize: {
+    type: String as PropType<FontSizeKeys>,
+    required: false,
+  },
 });
 
 // Form Group
 const provider = useFormGroupProvider();
 provide(formGroupKey, provider);
-const { setLabelWidth } = provider;
+const { setLabelWidth, setLabelColor, setLabelFontSize } = provider;
 watch(props, (p) => p.labelWidth && setLabelWidth(p.labelWidth));
 onMounted(() => props.labelWidth && setLabelWidth(props.labelWidth));
+watch(props, (p) => p.labelColor && setLabelColor(p.labelColor));
+onMounted(() => props.labelColor && setLabelColor(props.labelColor));
+watch(props, (p) => p.labelFontSize && setLabelFontSize(p.labelFontSize));
+onMounted(() => props.labelFontSize && setLabelFontSize(props.labelFontSize));
 </script>

--- a/packages/wiz-ui/src/hooks/use-form-group-provider.ts
+++ b/packages/wiz-ui/src/hooks/use-form-group-provider.ts
@@ -1,3 +1,4 @@
+import { ColorKeys, FontSizeKeys } from "@wizleap-inc/wiz-ui-constants";
 import { ref, readonly, InjectionKey } from "vue";
 
 export const useFormGroupProvider = () => {
@@ -6,9 +7,23 @@ export const useFormGroupProvider = () => {
     labelWidth.value = value;
   };
 
+  const labelColor = ref<ColorKeys>("gray.900");
+  const setLabelColor = (value: ColorKeys) => {
+    labelColor.value = value;
+  };
+
+  const labelFontSize = ref<FontSizeKeys>("md");
+  const setLabelFontSize = (value: FontSizeKeys) => {
+    labelFontSize.value = value;
+  };
+
   return {
     labelWidth: readonly(labelWidth),
     setLabelWidth,
+    labelColor: readonly(labelColor),
+    setLabelColor,
+    labelFontSize: readonly(labelFontSize),
+    setLabelFontSize,
   };
 };
 


### PR DESCRIPTION
# タスク

resolve: #756

WizFormGroupでラベルのサイズと色を一括指定できるようにしました。
vue: http://localhost:6006/?path=/docs/custom-form-group--docs
vue_next: http://localhost:6007/?path=/docs/custom-form-group--docs