### PR TITLE
WizTransitionGraphのReact対応

### DIFF
--- a/.changeset/shiny-wolves-shop.md
+++ b/.changeset/shiny-wolves-shop.md
@@ -1,0 +1,5 @@
+---
+"@wizleap-inc/wiz-ui-react": minor
+---
+
+WizTransitionGraph の React 対応

--- a/packages/wiz-ui-react/src/components/base/graphs/index.ts
+++ b/packages/wiz-ui-react/src/components/base/graphs/index.ts
@@ -1,0 +1,1 @@
+export * from "./transition";

--- a/packages/wiz-ui-react/src/components/base/graphs/transition/components/bar.tsx
+++ b/packages/wiz-ui-react/src/components/base/graphs/transition/components/bar.tsx
@@ -1,0 +1,198 @@
+import * as styles from "@wizleap-inc/wiz-ui-styles/bases/transition-graph.css";
+import clsx from "clsx";
+import { FC, useEffect, useMemo, useRef } from "react";
+
+type Props = {
+  label: string;
+  frequency: number;
+  lastFrequency: number | null;
+  maxFrequency: number;
+};
+
+export const Bar: FC<Props> = ({
+  label,
+  frequency,
+  lastFrequency,
+  maxFrequency,
+}) => {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const transitionRef = useRef<HTMLDivElement>(null);
+  const transitionLineRef = useRef<HTMLDivElement>(null);
+  const transitionLabelRef = useRef<HTMLDivElement>(null);
+  const frequencyRef = useRef<HTMLSpanElement>(null);
+  const currentBarRef = useRef<HTMLDivElement>(null);
+
+  const frequencyRatio = maxFrequency === 0 ? 0 : frequency / maxFrequency;
+  const transitionData = useMemo(() => {
+    if (lastFrequency === null) {
+      return null;
+    }
+    return {
+      lastFrequencyRatio: maxFrequency === 0 ? 0 : lastFrequency / maxFrequency,
+      frequencyRatioChange:
+        lastFrequency === 0 ? 0 : frequency / lastFrequency - 1,
+      isDropped: frequency < lastFrequency,
+    };
+  }, [frequency, lastFrequency, maxFrequency]);
+
+  useEffect(() => {
+    const wrapperElm = wrapperRef.current;
+    const transitionElm = transitionRef.current;
+    const transitionLineElm = transitionLineRef.current;
+    const transitionLabelElm = transitionLabelRef.current;
+
+    if (
+      !transitionData ||
+      !wrapperElm ||
+      !transitionElm ||
+      !transitionLineElm ||
+      !transitionLabelElm
+    )
+      return;
+
+    const updateTransitionStyles = () => {
+      const transitionWidth = transitionElm.offsetWidth;
+      const transitionHeight = transitionElm.offsetHeight;
+      const lineWidth = Math.sqrt(
+        Math.pow(transitionWidth, 2) + Math.pow(transitionHeight, 2)
+      );
+      const lineTilt = transitionData.isDropped
+        ? Math.atan(transitionHeight / transitionWidth)
+        : -1 * Math.atan(transitionHeight / transitionWidth);
+
+      transitionLineElm.style.width = `${lineWidth}px`;
+      transitionLineElm.style.transform = `rotate(${lineTilt}rad)`;
+
+      if (
+        transitionHeight +
+          transitionElm.offsetTop +
+          transitionLabelElm.offsetHeight <
+        wrapperElm.offsetHeight
+      ) {
+        // 下側にラベルを表示
+        transitionLabelElm.style.top = "100%";
+        transitionLabelElm.style.bottom = "unset";
+      } else {
+        // 上側にラベルを表示
+        transitionLabelElm.style.top = "unset";
+        transitionLabelElm.style.bottom = "100%";
+      }
+    };
+    const transitionResizeObserver = new ResizeObserver(() => {
+      updateTransitionStyles();
+    });
+    transitionResizeObserver.observe(transitionElm);
+    return () => {
+      transitionResizeObserver.disconnect();
+    };
+  }, [transitionData]);
+
+  useEffect(() => {
+    if (frequency === 0) return;
+
+    const currentBarElm = currentBarRef.current;
+    const frequencyElm = frequencyRef.current;
+
+    if (!currentBarElm || !frequencyElm) return;
+
+    const updateFrequencyStyles = () => {
+      if (frequencyElm.offsetHeight > currentBarElm.offsetHeight) {
+        // ラベルの高さがバーの高さを超える場合、ラベルをバーの外側に表示
+        frequencyElm.style.top = "unset";
+        frequencyElm.style.bottom = "100%";
+        frequencyElm.style.color = "#606166";
+        return;
+      }
+      const heightDelta =
+        currentBarElm.offsetHeight - frequencyElm.offsetHeight;
+      const defaultVerticalMargin = 8;
+      const actualMargin = Math.min(defaultVerticalMargin, heightDelta / 2);
+      frequencyElm.style.top = `${actualMargin}px`;
+      frequencyElm.style.bottom = "unset";
+      frequencyElm.style.color = "";
+    };
+
+    const currentBarResizeObserver = new ResizeObserver(() => {
+      updateFrequencyStyles();
+    });
+    currentBarResizeObserver.observe(currentBarElm);
+    return () => {
+      currentBarResizeObserver.disconnect();
+    };
+  }, [frequency]);
+
+  return (
+    <div ref={wrapperRef} className={styles.graphBarStyle}>
+      <span className={styles.graphBarLabelStyle}>{label}</span>
+      {transitionData !== null && (
+        <>
+          <div
+            ref={transitionRef}
+            className={styles.graphBarTransitionStyle}
+            style={{
+              height: `${
+                Math.abs(transitionData.lastFrequencyRatio - frequencyRatio) *
+                100
+              }%`,
+              top: `${Math.min(
+                (1 - transitionData.lastFrequencyRatio) * 100,
+                (1 - frequencyRatio) * 100
+              )}%`,
+            }}
+          >
+            <div
+              ref={transitionLineRef}
+              className={styles.graphBarTransitionLineStyle}
+              style={{
+                display:
+                  frequency === 0 && lastFrequency === 0 ? "none" : "block",
+                transformOrigin: transitionData.isDropped
+                  ? "left top"
+                  : "left bottom",
+                top: transitionData.isDropped ? "0" : "100%",
+              }}
+            />
+            <div
+              ref={transitionLabelRef}
+              className={styles.graphBarTransitionLabelStyle}
+            >
+              {frequency === 0 && lastFrequency === 0
+                ? "―"
+                : Math.abs(
+                    Math.floor(transitionData.frequencyRatioChange * 100)
+                  )}
+              %
+              <br />
+              {transitionData.isDropped ? "Dropped" : "Gained"}
+            </div>
+          </div>
+          <div
+            className={clsx(
+              styles.graphBarItemStyle,
+              styles.graphBarItemIndexStyle["last"]
+            )}
+            style={{
+              height: `${transitionData.lastFrequencyRatio * 100}%`,
+            }}
+          />
+        </>
+      )}
+      <div
+        ref={currentBarRef}
+        className={clsx(
+          styles.graphBarItemStyle,
+          styles.graphBarItemIndexStyle["current"]
+        )}
+        style={{
+          height: `${frequencyRatio * 100}%`,
+        }}
+      >
+        {frequency !== 0 && (
+          <span ref={frequencyRef} className={styles.graphBarNumberStyle}>
+            {frequency}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/packages/wiz-ui-react/src/components/base/graphs/transition/components/index.ts
+++ b/packages/wiz-ui-react/src/components/base/graphs/transition/components/index.ts
@@ -1,0 +1,1 @@
+export { WizTransitionGraph } from "./transition-graph";

--- a/packages/wiz-ui-react/src/components/base/graphs/transition/components/transition-graph.tsx
+++ b/packages/wiz-ui-react/src/components/base/graphs/transition/components/transition-graph.tsx
@@ -1,0 +1,71 @@
+import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
+import * as styles from "@wizleap-inc/wiz-ui-styles/bases/transition-graph.css";
+import clsx from "clsx";
+import { FC, ReactNode, useMemo } from "react";
+
+import { Bar } from "./bar";
+
+type TransitionGraphData = {
+  label: string;
+  frequency: number;
+};
+
+type Props = {
+  data: TransitionGraphData[];
+  children?: ReactNode;
+};
+
+const TransitionGraph: FC<Props> = ({ data, children }) => {
+  const maxFrequency = useMemo(
+    () => Math.max(...data.map((item) => item.frequency)),
+    [data]
+  );
+
+  const formattedBarData = useMemo(
+    () =>
+      data.map((item, i) => ({
+        ...item,
+        lastFrequency: i === 0 ? null : data[i - 1].frequency,
+      })),
+    [data]
+  );
+
+  return (
+    <div className={styles.graphContainerStyle}>
+      <div className={styles.graphSideStyle}>
+        <span
+          className={clsx(
+            styles.graphSideLabelStyle,
+            styles.graphSideLabelPositionStyle["max"]
+          )}
+        >
+          {maxFrequency}
+        </span>
+        <span
+          className={clsx(
+            styles.graphSideLabelStyle,
+            styles.graphSideLabelPositionStyle["half"]
+          )}
+        >
+          {Math.ceil(maxFrequency / 2)}
+        </span>
+      </div>
+      <div className={styles.graphContainerBodyStyle}>
+        <div className={styles.graphBodyStyle}>
+          {formattedBarData.map((item, i) => (
+            <Bar
+              key={`${i}-${item.label}-${item.frequency}-${item.lastFrequency}`}
+              {...item}
+              maxFrequency={maxFrequency}
+            />
+          ))}
+        </div>
+        <div className={styles.summaryLabelStyle}>{children}</div>
+      </div>
+    </div>
+  );
+};
+
+TransitionGraph.displayName = ComponentName.TransitionGraph;
+
+export const WizTransitionGraph = TransitionGraph;

--- a/packages/wiz-ui-react/src/components/base/graphs/transition/index.ts
+++ b/packages/wiz-ui-react/src/components/base/graphs/transition/index.ts
@@ -1,0 +1,1 @@
+export * from "./components";

--- a/packages/wiz-ui-react/src/components/base/graphs/transition/stories/transition-graph.stories.tsx
+++ b/packages/wiz-ui-react/src/components/base/graphs/transition/stories/transition-graph.stories.tsx
@@ -1,0 +1,76 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { ComponentProps } from "react";
+
+import { WizTransitionGraph } from "../components";
+
+const meta: Meta<typeof WizTransitionGraph> = {
+  title: "Base/Graphs/Transition",
+  component: WizTransitionGraph,
+  parameters: {
+    docs: {
+      description: {
+        component: `
+frequencyの値が一番大きいdataが最大値となるようにグラフが描画されます。
+減少する遷移の場合、Droppedというラベルが付きます。
+      `,
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof WizTransitionGraph>;
+
+const DUMMY_DATA: ComponentProps<typeof WizTransitionGraph>["data"] = [
+  {
+    label: "2022/5",
+    frequency: 75,
+  },
+  {
+    label: "2022/6",
+    frequency: 40,
+  },
+  {
+    label: "2022/7",
+    frequency: 25,
+  },
+];
+
+export const Default: Story = {
+  args: {
+    data: DUMMY_DATA,
+  },
+};
+
+export const Gain: Story = {
+  args: {
+    data: [...DUMMY_DATA].reverse(),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "増加する遷移の場合、Gainedというラベルが付きます。",
+      },
+    },
+  },
+};
+
+export const Children: Story = {
+  args: {
+    data: DUMMY_DATA,
+    children: (
+      <span>
+        ここは
+        <br />
+        childrenです
+      </span>
+    ),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "childrenを使うことで、ラベルの表示をカスタマイズできます。",
+      },
+    },
+  },
+};

--- a/packages/wiz-ui-react/src/components/base/index.ts
+++ b/packages/wiz-ui-react/src/components/base/index.ts
@@ -12,3 +12,4 @@ export * from "./menu";
 export * from "./stack";
 export * from "./anchor";
 export * from "./inputs";
+export * from "./graphs";


### PR DESCRIPTION
# タスク

resolve: #812 

<!-- reviewerにオーナーを追加してください-->

* 追加対応
  * 各バー内のラベルについて、`padding` を編集しながら `offsetHeight` を参照するのは予期せぬ挙動に繋がりそうだったので、`padding` はいじらずに `top` か `bottom` のみで位置を調整するように変更
  * 各バーにおいて、`isFIrst` ではなく `lastFrequency` の有無によって表示を切り替えるように変更
  * 何もしていない要素を削除
