### PR TITLE
fix: [React] いくつかの微修正

### DIFF
--- a/.changeset/tender-toes-speak.md
+++ b/.changeset/tender-toes-speak.md
@@ -1,0 +1,5 @@
+---
+"@wizleap-inc/wiz-ui-react": patch
+---
+
+WizPopup の座標計算方法を修正

--- a/packages/wiz-ui-react/src/components/base/popup/components/popup.tsx
+++ b/packages/wiz-ui-react/src/components/base/popup/components/popup.tsx
@@ -72,12 +72,14 @@ const Popup = ({
       const contentRect = popupRef.current?.getBoundingClientRect();
       const wrapOutOfBound = (dir: DirectionValue) => {
         if (isDirectionFixed || !contentRect) return dir;
-        const bodyRect = document.body.getBoundingClientRect();
         const fontSize = window.getComputedStyle(document.body).fontSize;
         const gapPx =
           parseFloat(getSpacingCss(gap) || "0") * parseFloat(fontSize);
         return wrapDirection[dir]({
-          bound: bodyRect,
+          bound: {
+            width: document.body.clientWidth,
+            height: window.innerHeight,
+          },
           content: contentRect,
           anchor: anchorRect,
           gap: gapPx,

--- a/packages/wiz-ui-react/src/components/base/popup/components/popup.tsx
+++ b/packages/wiz-ui-react/src/components/base/popup/components/popup.tsx
@@ -78,7 +78,7 @@ const Popup = ({
         return wrapDirection[dir]({
           bound: {
             width: document.body.clientWidth,
-            height: window.innerHeight,
+            height: Math.max(document.body.clientHeight, window.innerHeight),
           },
           content: contentRect,
           anchor: anchorRect,

--- a/packages/wiz-ui-react/src/components/base/popup/test/wrap.test.ts
+++ b/packages/wiz-ui-react/src/components/base/popup/test/wrap.test.ts
@@ -5,7 +5,7 @@ import { wrapDirection, Args } from "../utils/wrap";
 describe("Popup Wrapping", () => {
   it("popupが境界内に存在するとき、回り込みロジックは発火しません。", () => {
     const args: Args = {
-      bound: { x: 0, y: 0, width: 100, height: 100 } as DOMRect,
+      bound: { width: 100, height: 100 },
       content: { x: 10, y: 10, width: 20, height: 20 } as DOMRect,
       anchor: { x: 50, y: 50, width: 30, height: 30 } as DOMRect,
       gap: 0,
@@ -30,7 +30,7 @@ describe("Popup Wrapping", () => {
 
   it("Anchor: 左上", () => {
     const args: Args = {
-      bound: { x: 0, y: 0, width: 100, height: 100 } as DOMRect,
+      bound: { width: 100, height: 100 },
       content: { x: 0, y: 0, width: 10, height: 10 } as DOMRect,
       anchor: { x: 5, y: 5, width: 10, height: 10 } as DOMRect,
       gap: 0,
@@ -80,7 +80,7 @@ describe("Popup Wrapping", () => {
 
   it("Anchor: 左下", () => {
     const args: Args = {
-      bound: { x: 0, y: 0, width: 100, height: 100 } as DOMRect,
+      bound: { width: 100, height: 100 },
       content: { x: 0, y: 0, width: 10, height: 10 } as DOMRect,
       anchor: { x: 5, y: 95, width: 10, height: 10 } as DOMRect,
       gap: 0,
@@ -105,7 +105,7 @@ describe("Popup Wrapping", () => {
 
   it("Anchor: 上", () => {
     const args: Args = {
-      bound: { x: 0, y: 0, width: 100, height: 100 } as DOMRect,
+      bound: { width: 100, height: 100 },
       content: { x: 0, y: 0, width: 10, height: 10 } as DOMRect,
       anchor: { x: 50, y: 5, width: 10, height: 10 } as DOMRect,
       gap: 0,
@@ -130,7 +130,7 @@ describe("Popup Wrapping", () => {
 
   it("Anchor: 下", () => {
     const args: Args = {
-      bound: { x: 0, y: 0, width: 100, height: 100 } as DOMRect,
+      bound: { width: 100, height: 100 },
       content: { x: 0, y: 0, width: 10, height: 10 } as DOMRect,
       anchor: { x: 50, y: 95, width: 10, height: 10 } as DOMRect,
       gap: 0,
@@ -155,7 +155,7 @@ describe("Popup Wrapping", () => {
 
   it("Anchor: 右上", () => {
     const args: Args = {
-      bound: { x: 0, y: 0, width: 100, height: 100 } as DOMRect,
+      bound: { width: 100, height: 100 },
       content: { x: 0, y: 0, width: 10, height: 10 } as DOMRect,
       anchor: { x: 95, y: 5, width: 10, height: 10 } as DOMRect,
       gap: 0,
@@ -180,7 +180,7 @@ describe("Popup Wrapping", () => {
 
   it("Anchor: 右", () => {
     const args: Args = {
-      bound: { x: 0, y: 0, width: 100, height: 100 } as DOMRect,
+      bound: { width: 100, height: 100 },
       content: { x: 0, y: 0, width: 10, height: 10 } as DOMRect,
       anchor: { x: 95, y: 50, width: 10, height: 10 } as DOMRect,
       gap: 0,
@@ -205,7 +205,7 @@ describe("Popup Wrapping", () => {
 
   it("Anchor: 右下", () => {
     const args: Args = {
-      bound: { x: 0, y: 0, width: 100, height: 100 } as DOMRect,
+      bound: { width: 100, height: 100 },
       content: { x: 0, y: 0, width: 10, height: 10 } as DOMRect,
       anchor: { x: 95, y: 95, width: 10, height: 10 } as DOMRect,
       gap: 0,

--- a/packages/wiz-ui-react/src/components/base/popup/utils/wrap.ts
+++ b/packages/wiz-ui-react/src/components/base/popup/utils/wrap.ts
@@ -3,7 +3,7 @@ import { DirectionValue } from "../types/direction";
 import { createDirectionValue } from "./direction-value";
 
 export type Args = {
-  bound: DOMRect;
+  bound: { width: number; height: number };
   content: DOMRect;
   anchor: DOMRect;
   gap: number;

--- a/packages/wiz-ui-react/src/components/base/stack/stories/h-stack.stories.tsx
+++ b/packages/wiz-ui-react/src/components/base/stack/stories/h-stack.stories.tsx
@@ -12,7 +12,7 @@ const spacingControls = spacingKeys.reduce((acc, key) => {
     options: SPACING_ACCESSORS,
   };
   return acc;
-}, {} as Record<string, any>);
+}, {} as Record<string, unknown>);
 
 const meta: Meta<typeof WizHStack> = {
   title: "Base/Stack/HStack",

--- a/packages/wiz-ui-react/src/components/base/stack/stories/stack.stories.tsx
+++ b/packages/wiz-ui-react/src/components/base/stack/stories/stack.stories.tsx
@@ -12,7 +12,7 @@ const spacingControls = spacingKeys.reduce((acc, key) => {
     options: SPACING_ACCESSORS,
   };
   return acc;
-}, {} as Record<string, any>);
+}, {} as Record<string, unknown>);
 
 const meta: Meta<typeof WizStack> = {
   title: "Base/Stack/Stack",

--- a/packages/wiz-ui-react/src/components/base/stack/stories/v-stack.stories.tsx
+++ b/packages/wiz-ui-react/src/components/base/stack/stories/v-stack.stories.tsx
@@ -12,7 +12,7 @@ const spacingControls = spacingKeys.reduce((acc, key) => {
     options: SPACING_ACCESSORS,
   };
   return acc;
-}, {} as Record<string, any>);
+}, {} as Record<string, unknown>);
 
 const meta: Meta<typeof WizVStack> = {
   title: "Base/Stack/VStack",


### PR DESCRIPTION
## やったこと

* React 版の Popup で、全体の高さを `document.body` から取得していた関係で、storybook などで body 自体が小さいときに意図せず回り込みが効いてしまう場合があったので、全体の高さを `document.body.clientHeight` と `widnow.innerHeight` のうちの大きい方を採用するように変更
* `any` 型を使っている部分を修正