### PR TITLE
WizSearchSelector : 検索時に該当した文字のみ抽出

### DIFF
--- a/.changeset/rare-cameras-raise.md
+++ b/.changeset/rare-cameras-raise.md
@@ -1,0 +1,6 @@
+---
+"@wizleap-inc/wiz-ui-next": patch
+"@wizleap-inc/wiz-ui": patch
+---
+
+[#814] (WizSearchSelector) 検索単語に近い単語だけを抽出

--- a/packages/wiz-ui-next/src/components/base/inputs/search-selector/search-selector.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/search-selector/search-selector.vue
@@ -212,13 +212,24 @@ const toggleDropdown = () => {
 
 const deepCopy = <T>(ary: T): T => JSON.parse(JSON.stringify(ary));
 
-const selectByLevenshtein = (options: SelectBoxOption[], target: string) => {
+const selectByLevenshteinAndPartialMatch = (
+  options: SelectBoxOption[],
+  target: string
+) => {
   const dist = options.reduce((acc, str) => {
     acc[str.label] = levenshteinDistance(str.label, target);
     return acc;
   }, {} as { [key: string]: number });
-  const closestWords = Math.min(...Object.values(dist));
-  return options.filter((option) => dist[option.label] === closestWords);
+  const minLength = Math.min(...Object.values(dist));
+  const closestWords = options.filter(
+    (option) => dist[option.label] === minLength
+  );
+
+  const exactMatch = options.filter((option) => {
+    const isIncluded = option.label.indexOf(target) !== -1;
+    return isIncluded && !closestWords.includes(option);
+  });
+  return closestWords.concat(exactMatch);
 };
 
 const valueToOption = computed(() =>
@@ -241,7 +252,10 @@ const setUnselectableRef =
 const filteredOptions = computed(() => {
   const sortedOptions =
     props.searchValue.length !== 0
-      ? selectByLevenshtein(deepCopy(props.options), props.searchValue)
+      ? selectByLevenshteinAndPartialMatch(
+          deepCopy(props.options),
+          props.searchValue
+        )
       : props.options;
   const removeSelectedOptions = (options: SelectBoxOption[]) => {
     return options.filter((v) => {

--- a/packages/wiz-ui-next/src/components/base/inputs/search-selector/search-selector.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/search-selector/search-selector.vue
@@ -212,12 +212,13 @@ const toggleDropdown = () => {
 
 const deepCopy = <T>(ary: T): T => JSON.parse(JSON.stringify(ary));
 
-const sortByLevenshtein = (options: SelectBoxOption[], target: string) => {
+const selectByLevenshtein = (options: SelectBoxOption[], target: string) => {
   const dist = options.reduce((acc, str) => {
     acc[str.label] = levenshteinDistance(str.label, target);
     return acc;
   }, {} as { [key: string]: number });
-  return options.sort((a, b) => dist[a.label] - dist[b.label]);
+  const closestWords = Math.min(...Object.values(dist));
+  return options.filter((option) => dist[option.label] === closestWords);
 };
 
 const valueToOption = computed(() =>
@@ -240,7 +241,7 @@ const setUnselectableRef =
 const filteredOptions = computed(() => {
   const sortedOptions =
     props.searchValue.length !== 0
-      ? sortByLevenshtein(deepCopy(props.options), props.searchValue)
+      ? selectByLevenshtein(deepCopy(props.options), props.searchValue)
       : props.options;
   const removeSelectedOptions = (options: SelectBoxOption[]) => {
     return options.filter((v) => {

--- a/packages/wiz-ui/src/components/base/inputs/search-selector/search-selector.vue
+++ b/packages/wiz-ui/src/components/base/inputs/search-selector/search-selector.vue
@@ -212,13 +212,24 @@ const toggleDropdown = () => {
 
 const deepCopy = <T>(ary: T): T => JSON.parse(JSON.stringify(ary));
 
-const selectByLevenshtein = (options: SelectBoxOption[], target: string) => {
+const selectByLevenshteinAndPartialMatch = (
+  options: SelectBoxOption[],
+  target: string
+) => {
   const dist = options.reduce((acc, str) => {
     acc[str.label] = levenshteinDistance(str.label, target);
     return acc;
   }, {} as { [key: string]: number });
-  const closestWords = Math.min(...Object.values(dist));
-  return options.filter((option) => dist[option.label] === closestWords);
+  const minLength = Math.min(...Object.values(dist));
+  const closestWords = options.filter(
+    (option) => dist[option.label] === minLength
+  );
+
+  const exactMatch = options.filter((option) => {
+    const isIncluded = option.label.indexOf(target) !== -1;
+    return isIncluded && !closestWords.includes(option);
+  });
+  return closestWords.concat(exactMatch);
 };
 
 const valueToOption = computed(() =>
@@ -241,7 +252,10 @@ const setUnselectableRef =
 const filteredOptions = computed(() => {
   const sortedOptions =
     props.searchValue.length !== 0
-      ? selectByLevenshtein(deepCopy(props.options), props.searchValue)
+      ? selectByLevenshteinAndPartialMatch(
+          deepCopy(props.options),
+          props.searchValue
+        )
       : props.options;
   const removeSelectedOptions = (options: SelectBoxOption[]) => {
     return options.filter((v) => {

--- a/packages/wiz-ui/src/components/base/inputs/search-selector/search-selector.vue
+++ b/packages/wiz-ui/src/components/base/inputs/search-selector/search-selector.vue
@@ -212,12 +212,13 @@ const toggleDropdown = () => {
 
 const deepCopy = <T>(ary: T): T => JSON.parse(JSON.stringify(ary));
 
-const sortByLevenshtein = (options: SelectBoxOption[], target: string) => {
+const selectByLevenshtein = (options: SelectBoxOption[], target: string) => {
   const dist = options.reduce((acc, str) => {
     acc[str.label] = levenshteinDistance(str.label, target);
     return acc;
   }, {} as { [key: string]: number });
-  return options.sort((a, b) => dist[a.label] - dist[b.label]);
+  const closestWords = Math.min(...Object.values(dist));
+  return options.filter((option) => dist[option.label] === closestWords);
 };
 
 const valueToOption = computed(() =>
@@ -240,7 +241,7 @@ const setUnselectableRef =
 const filteredOptions = computed(() => {
   const sortedOptions =
     props.searchValue.length !== 0
-      ? sortByLevenshtein(deepCopy(props.options), props.searchValue)
+      ? selectByLevenshtein(deepCopy(props.options), props.searchValue)
       : props.options;
   const removeSelectedOptions = (options: SelectBoxOption[]) => {
     return options.filter((v) => {


### PR DESCRIPTION
# タスク

resolve: #793

## 修正内容について

仕様について特に書かれていなかったので、レーベンシュタイン距離で最も近い文字のみを抽出するように実装した。これでは、2 番目に近い文字などを検索することが難しくなると思われるため、二番目に近いものも抽出できるようにしたほうがいいかもしれないので、動作時のレビューをお願いします。




<!-- reviewerにオーナーを追加してください-->
