### PR TITLE
feat: WizSearchSelectorのReact対応

### DIFF
--- a/.changeset/four-sheep-check.md
+++ b/.changeset/four-sheep-check.md
@@ -1,0 +1,5 @@
+---
+"@wizleap-inc/wiz-ui-react": minor
+---
+
+WizSearchSelector の React 対応

--- a/packages/wiz-ui-react/src/components/base/inputs/index.ts
+++ b/packages/wiz-ui-react/src/components/base/inputs/index.ts
@@ -1,6 +1,7 @@
 export * from "./checkbox";
 export * from "./radio";
 export * from "./search-input";
+export * from "./search-selector";
 export * from "./selectbox";
 export * from "./text";
 export * from "./toggle-switch";

--- a/packages/wiz-ui-react/src/components/base/inputs/search-selector/components/index.ts
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-selector/components/index.ts
@@ -1,0 +1,1 @@
+export { WizSearchSelector } from "./search-selector";

--- a/packages/wiz-ui-react/src/components/base/inputs/search-selector/components/search-selector-helper.ts
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-selector/components/search-selector-helper.ts
@@ -1,0 +1,51 @@
+import { SearchSelectorOption } from "./types";
+
+function levenshteinDistance(s1: string, s2: string): number {
+  const dist: number[][] = Array.from({ length: s1.length + 1 }, () =>
+    Array(s2.length + 1).fill(0)
+  );
+  for (let i = 0; i < s1.length + 1; i++) dist[i][0] = i;
+  for (let i = 0; i < s2.length + 1; i++) dist[0][i] = i;
+  for (let i = 1; i < s1.length + 1; i++) {
+    for (let j = 1; j < s2.length + 1; j++) {
+      const cost = s1[i - 1] === s2[j - 1] ? 0 : 1;
+      dist[i][j] = Math.min(
+        dist[i - 1][j] + 1,
+        dist[i][j - 1] + 1,
+        dist[i - 1][j - 1] + cost
+      );
+    }
+  }
+  return dist[s1.length][s2.length] / Math.max(s1.length, s2.length);
+}
+
+export function filterOptions(
+  options: SearchSelectorOption[],
+  searchText: string
+) {
+  if (searchText.length === 0) {
+    return options;
+  }
+  const levenshteinDistanceMap = options.reduce<Record<string, number>>(
+    (map, option) => {
+      map[option.label] = levenshteinDistance(option.label, searchText);
+      return map;
+    },
+    {}
+  );
+  const minLevenshteinDistance = Math.min(
+    ...Object.values(levenshteinDistanceMap)
+  );
+
+  return options.filter((option) => {
+    if (levenshteinDistanceMap[option.label] === minLevenshteinDistance) {
+      // レーベンシュタイン距離が最小に等しい
+      return true;
+    }
+    if (option.label.includes(searchText)) {
+      // 部分一致
+      return true;
+    }
+    return false;
+  });
+}

--- a/packages/wiz-ui-react/src/components/base/inputs/search-selector/components/search-selector.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-selector/components/search-selector.tsx
@@ -1,0 +1,326 @@
+import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
+import * as styles from "@wizleap-inc/wiz-ui-styles/bases/search-selector.css";
+import { inputBorderStyle } from "@wizleap-inc/wiz-ui-styles/commons";
+import clsx from "clsx";
+import {
+  FC,
+  FocusEventHandler,
+  KeyboardEvent,
+  KeyboardEventHandler,
+  MouseEventHandler,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import {
+  WizHStack,
+  WizIAddCircle,
+  WizIClose,
+  WizIExpandLess,
+  WizIExpandMore,
+  WizIcon,
+  WizPopup,
+  WizPopupButtonGroup,
+} from "@/components";
+import { ButtonGroupItem } from "@/components/base/popup-button-group/types";
+import { FormControlContext } from "@/components/custom/form/components/form-control-context";
+
+import { filterOptions } from "./search-selector-helper";
+import { SearchSelectorOption } from "./types";
+
+type Props = {
+  options: SearchSelectorOption[];
+  values: number[];
+  placeholder?: string;
+  width?: string;
+  disabled?: boolean;
+  expand?: boolean;
+  multiSelectable?: boolean;
+  addable?: boolean;
+  error?: boolean;
+  isDirectionFixed?: boolean;
+  onChangeValues: (values: number[]) => void;
+  onCreate?: (label: string) => void;
+};
+
+const SearchSelector: FC<Props> = ({
+  options,
+  values,
+  placeholder = "選択してください",
+  width = "10rem",
+  disabled = false,
+  expand,
+  multiSelectable = false,
+  addable = false,
+  error,
+  isDirectionFixed = false,
+  onChangeValues,
+  onCreate,
+}) => {
+  const [searchText, setSearchText] = useState("");
+  const [isPopupOpen, setIsPopupOpen] = useState(false);
+  const [isFocused, setIsFocused] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const searchTextboxRef = useRef<HTMLInputElement>(null);
+  const clearButtonsRef = useRef<Array<HTMLButtonElement | null>>([]);
+  const popupRef = useRef<HTMLDivElement>(null);
+  const formControl = useContext(FormControlContext);
+
+  const isError = error || formControl.error;
+
+  const selectedOptions = useMemo(
+    () => options.filter((option) => values.includes(option.value)),
+    [options, values]
+  );
+
+  useEffect(() => {
+    // 選択解除ボタンの ref の数を補正
+    clearButtonsRef.current = clearButtonsRef.current.slice(
+      0,
+      selectedOptions.length
+    );
+  }, [selectedOptions.length]);
+
+  const buttonGroupOptions: ButtonGroupItem[] = useMemo(() => {
+    const filteredOptions = filterOptions(options, searchText).filter(
+      (matchedOption) => {
+        return !values.some((value) => matchedOption.value === value);
+      }
+    );
+    const buttonGroupOptions: ButtonGroupItem[] = filteredOptions.map(
+      (option) => {
+        return {
+          kind: "button",
+          option: {
+            label: option.label,
+            value: option.value,
+            onClick: () => {
+              setSearchText("");
+              if (multiSelectable) {
+                onChangeValues([...values, option.value]);
+                searchTextboxRef.current?.focus();
+              } else {
+                onChangeValues([option.value]);
+                setIsPopupOpen(false);
+              }
+            },
+          },
+        };
+      }
+    );
+    const shouldShowAddButton =
+      addable &&
+      searchText !== "" &&
+      options.every((option) => option.label !== searchText);
+    return shouldShowAddButton
+      ? [
+          {
+            kind: "button",
+            option: {
+              label: searchText,
+              icon: WizIAddCircle,
+              iconDefaultColor: "green.800",
+              value: -1,
+              onClick: () => onCreate?.(searchText),
+            },
+          },
+          ...buttonGroupOptions,
+        ]
+      : buttonGroupOptions;
+  }, [
+    addable,
+    multiSelectable,
+    onChangeValues,
+    onCreate,
+    options,
+    searchText,
+    values,
+  ]);
+
+  const unselectOption = (option: SearchSelectorOption) => {
+    onChangeValues(values.filter((value) => value !== option.value));
+    setTimeout(() => {
+      // input 要素が描画されるのを待ってフォーカス
+      searchTextboxRef.current?.focus();
+    });
+  };
+
+  const handleClickClearButton = (
+    option: SearchSelectorOption
+  ): MouseEventHandler => {
+    return (e) => {
+      e.stopPropagation();
+      unselectOption(option);
+      setIsPopupOpen(true);
+    };
+  };
+
+  const focusComponent = () => {
+    setIsFocused(true);
+    setIsPopupOpen(true);
+  };
+
+  const handleClickWrapper = () => {
+    if (disabled) {
+      return;
+    }
+    if (searchTextboxRef.current) {
+      searchTextboxRef.current.focus();
+    } else {
+      focusComponent();
+    }
+  };
+
+  const handleBlurComponent: FocusEventHandler = (e) => {
+    if (
+      popupRef.current?.contains(e.relatedTarget) === false &&
+      wrapperRef.current?.contains(e.relatedTarget) === false
+    ) {
+      setIsFocused(false);
+      setIsPopupOpen(false);
+    }
+  };
+
+  const keyDownHandlers = {
+    clearButton: (option: SearchSelectorOption): KeyboardEventHandler => {
+      return (e) => {
+        if (e.key === "Backspace") {
+          unselectOption(option);
+        }
+      };
+    },
+    input: (e: KeyboardEvent) => {
+      if (
+        e.key === "Backspace" &&
+        searchText === "" &&
+        clearButtonsRef.current.length > 0
+      ) {
+        clearButtonsRef.current.at(-1)?.focus();
+      }
+    },
+  };
+
+  useEffect(() => {
+    const handleEscape = (e: globalThis.KeyboardEvent) => {
+      if (e.key === "Escape" || e.key === "Esc") {
+        setIsPopupOpen(false);
+      }
+    };
+    document.addEventListener("keydown", handleEscape);
+    return () => {
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, []);
+
+  const inputBorderStyleKey = () => {
+    if (isError) return "error";
+    if (isPopupOpen || isFocused) return "active";
+    return "default";
+  };
+
+  const cursorStyleKey = () => {
+    if (disabled) return "disabled";
+    if (!multiSelectable && values.length > 0) return "singleSelected";
+    return "default";
+  };
+
+  return (
+    <>
+      <div
+        ref={wrapperRef}
+        className={clsx(
+          styles.selectBoxStyle,
+          inputBorderStyle[inputBorderStyleKey()],
+          disabled && styles.selectBoxDisabledStyle,
+          styles.selectBoxCursorStyle[cursorStyleKey()]
+        )}
+        style={{ width: expand ? "100%" : width }}
+        role="group"
+        onClick={handleClickWrapper}
+        onFocus={focusComponent}
+        onBlur={handleBlurComponent}
+      >
+        <div className={styles.selectBoxInnerBoxStyle}>
+          <WizHStack align="center" height="100%" gap="xs" pr="xl">
+            {selectedOptions.map((selectedOption, i) => (
+              <span
+                key={`${selectedOption.label}-${selectedOption.value}`}
+                className={styles.selectBoxInnerBoxSelectedItemStyle}
+              >
+                <span className={styles.selectBoxInnerBoxSelectedLabelStyle}>
+                  {selectedOption.label}
+                </span>
+                <button
+                  ref={(ref) => (clearButtonsRef.current[i] = ref)}
+                  className={styles.selectBoxInnerBoxCloseButtonStyle}
+                  disabled={disabled}
+                  onClick={handleClickClearButton(selectedOption)}
+                  onKeyDown={keyDownHandlers.clearButton(selectedOption)}
+                >
+                  <span className={styles.selectBoxInnerBoxCloseStyle}>
+                    <WizIcon icon={WizIClose} size="xs" color="gray.500" />
+                  </span>
+                </button>
+              </span>
+            ))}
+            {(multiSelectable || values.length === 0) && (
+              <input
+                ref={searchTextboxRef}
+                className={styles.selectBoxSearchInputStyle}
+                value={searchText}
+                placeholder={
+                  selectedOptions.length === 0 ? placeholder : undefined
+                }
+                disabled={disabled}
+                onChange={(e) => {
+                  setSearchText(e.target.value);
+                  setIsPopupOpen(true);
+                }}
+                onKeyDown={keyDownHandlers.input}
+              />
+            )}
+          </WizHStack>
+        </div>
+        <div className={styles.selectBoxExpandIconStyle}>
+          {isPopupOpen ? (
+            <div className={styles.selectBoxInnerBoxLessStyle}>
+              <WizIcon icon={WizIExpandLess} color="green.800" />
+            </div>
+          ) : (
+            <div className={styles.selectBoxInnerBoxMoreStyle}>
+              <WizIcon icon={WizIExpandMore} />
+            </div>
+          )}
+        </div>
+      </div>
+      {buttonGroupOptions.length > 0 && (
+        <WizPopup
+          anchorElement={wrapperRef}
+          isOpen={isPopupOpen}
+          layer="popover"
+          isDirectionFixed={isDirectionFixed}
+          onClose={() => {
+            setIsFocused(false);
+            setIsPopupOpen(false);
+          }}
+        >
+          <div
+            ref={popupRef}
+            className={styles.selectBoxSelectorStyle}
+            style={{ minWidth: width }}
+            onBlur={handleBlurComponent}
+          >
+            <WizPopupButtonGroup options={buttonGroupOptions} />
+          </div>
+        </WizPopup>
+      )}
+    </>
+  );
+};
+
+SearchSelector.displayName = ComponentName.SearchSelector;
+
+export const WizSearchSelector = SearchSelector;

--- a/packages/wiz-ui-react/src/components/base/inputs/search-selector/components/search-selector.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-selector/components/search-selector.tsx
@@ -4,7 +4,6 @@ import { inputBorderStyle } from "@wizleap-inc/wiz-ui-styles/commons";
 import clsx from "clsx";
 import {
   FC,
-  FocusEventHandler,
   KeyboardEvent,
   KeyboardEventHandler,
   MouseEventHandler,
@@ -158,11 +157,6 @@ const SearchSelector: FC<Props> = ({
     };
   };
 
-  const focusComponent = () => {
-    setIsFocused(true);
-    setIsPopupOpen(true);
-  };
-
   const handleClickWrapper = () => {
     if (disabled) {
       return;
@@ -170,17 +164,8 @@ const SearchSelector: FC<Props> = ({
     if (searchTextboxRef.current) {
       searchTextboxRef.current.focus();
     } else {
-      focusComponent();
-    }
-  };
-
-  const handleBlurComponent: FocusEventHandler = (e) => {
-    if (
-      popupRef.current?.contains(e.relatedTarget) === false &&
-      wrapperRef.current?.contains(e.relatedTarget) === false
-    ) {
-      setIsFocused(false);
-      setIsPopupOpen(false);
+      setIsFocused(true);
+      setIsPopupOpen(true);
     }
   };
 
@@ -240,8 +225,11 @@ const SearchSelector: FC<Props> = ({
         style={{ width: expand ? "100%" : width }}
         role="group"
         onClick={handleClickWrapper}
-        onFocus={focusComponent}
-        onBlur={handleBlurComponent}
+        onFocus={() => {
+          setIsFocused(true);
+          setIsPopupOpen(true);
+        }}
+        onBlur={() => setIsFocused(false)}
       >
         <div className={styles.selectBoxInnerBoxStyle}>
           <WizHStack align="center" height="100%" gap="xs" pr="xl">
@@ -311,7 +299,6 @@ const SearchSelector: FC<Props> = ({
             ref={popupRef}
             className={styles.selectBoxSelectorStyle}
             style={{ minWidth: width }}
-            onBlur={handleBlurComponent}
           >
             <WizPopupButtonGroup options={buttonGroupOptions} />
           </div>

--- a/packages/wiz-ui-react/src/components/base/inputs/search-selector/components/types.ts
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-selector/components/types.ts
@@ -1,0 +1,5 @@
+export type SearchSelectorOption = {
+  label: string;
+  value: number;
+  exLabel?: string;
+};

--- a/packages/wiz-ui-react/src/components/base/inputs/search-selector/index.ts
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-selector/index.ts
@@ -1,0 +1,1 @@
+export * from "./components";

--- a/packages/wiz-ui-react/src/components/base/inputs/search-selector/stories/search-selector.stories.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-selector/stories/search-selector.stories.tsx
@@ -122,4 +122,16 @@ export const IsDirectionFixed: Story = {
     options: getDummyOptions("test", 3),
     isDirectionFixed: true,
   },
+  parameters: {
+    layout: "fullscreen",
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ height: "6.5rem" }}>
+        <div style={{ position: "absolute", bottom: "2rem", left: "1rem" }}>
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
 };

--- a/packages/wiz-ui-react/src/components/base/inputs/search-selector/stories/search-selector.stories.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-selector/stories/search-selector.stories.tsx
@@ -1,0 +1,125 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+import { Meta, StoryObj } from "@storybook/react";
+import { userEvent, within } from "@storybook/testing-library";
+import { useState } from "react";
+
+import { WizSearchSelector } from "..";
+import { SearchSelectorOption } from "../components/types";
+
+const meta: Meta<typeof WizSearchSelector> = {
+  title: "Base/Input/SearchSelector",
+  component: WizSearchSelector,
+  parameters: {
+    docs: {
+      description: {
+        component: `
+### WizSearchSelector
+WizSearchSelectorは、検索・新規追加可能なセレクタコンポーネントです。
+v-modelには選択中のアイテムを渡します。
+
+このコンポーネントを使用する場合には、以下のEmitを登録してください。
+- update:modelValue
+  - 選択したアイテムを追加する関数です。引数は追加するアイテムのvalue(id)です。
+- unselect
+  - 選択中のアイテムを解除する関数です。引数は解除するアイテムのvalue(id)です。
+- add
+  - オプションを追加するための関数です。addable=trueのとき必須となります。引数は追加するアイテムの文字列です。
+- toggle
+  - popupの開閉制御を行う関数です。isOpenのtrue/falseを切り替えます。
+- setSearchValue
+  - 検索する文字列を編集する関数です。searchValueの値を変更します。`,
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof WizSearchSelector>;
+
+const getDummyOptions = (label: string, count: number, exLabel?: string) => {
+  const options: SearchSelectorOption[] = [];
+  for (let i = 1; i <= count; i++) {
+    options.push({ label: label + i, value: i, exLabel });
+    options.push({ label: label + i * 10, value: i * 10, exLabel });
+  }
+  return options;
+};
+
+const getTemplate = (initialValues: number[] = []): Story => {
+  return {
+    render: (args) => {
+      const [values, setValues] = useState<number[]>(initialValues);
+      return (
+        <WizSearchSelector
+          {...args}
+          values={values}
+          onChangeValues={(changed) => setValues(changed)}
+        />
+      );
+    },
+    play: async ({ canvasElement }) => {
+      const canvas = within(canvasElement);
+      const group = canvas.getByRole("group");
+      userEvent.click(group);
+    },
+  };
+};
+
+export const Default: Story = {
+  ...getTemplate(),
+  args: {
+    options: getDummyOptions("test", 3),
+  },
+};
+
+export const LongWordSelector: Story = {
+  ...getTemplate(),
+  args: {
+    options: getDummyOptions("testtesttesttesttesttesttesttesttesttest", 3),
+  },
+};
+
+export const Disabled: Story = {
+  ...getTemplate(),
+  args: {
+    options: getDummyOptions("test", 3),
+    disabled: true,
+  },
+};
+
+export const Selecting: Story = {
+  ...getTemplate([1]),
+  args: {
+    options: getDummyOptions("test", 3),
+  },
+};
+
+export const MultiSelecting: Story = {
+  ...getTemplate([1, 2, 3]),
+  args: {
+    options: getDummyOptions("test", 3),
+    multiSelectable: true,
+    width: "300px",
+  },
+};
+
+export const Addable: Story = {
+  ...getTemplate(),
+  args: {
+    options: getDummyOptions("test", 3),
+    addable: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const textbox = canvas.getByRole("textbox");
+    userEvent.type(textbox, "new option");
+  },
+};
+
+export const IsDirectionFixed: Story = {
+  ...getTemplate(),
+  args: {
+    options: getDummyOptions("test", 3),
+    isDirectionFixed: true,
+  },
+};


### PR DESCRIPTION
# タスク

resolve: #866 

<!-- reviewerにオーナーを追加してください-->

* 追加対応
  * `WizPopup` において、`anchorElement` のリサイズ時にも位置が再計算されるように修正