### PR TITLE
Radio ボタンの a11y 化 (React)

### DIFF
--- a/.changeset/stupid-ants-provide.md
+++ b/.changeset/stupid-ants-provide.md
@@ -1,0 +1,5 @@
+---
+"@wizleap-inc/wiz-ui-react": patch
+---
+
+[#957] Radio の a11y 化 (React)

--- a/packages/wiz-ui-react/src/components/base/inputs/radio/components/radio.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/radio/components/radio.tsx
@@ -1,7 +1,7 @@
 import { ComponentName, SpacingKeys } from "@wizleap-inc/wiz-ui-constants";
 import * as styles from "@wizleap-inc/wiz-ui-styles/bases/radio-input.css";
 import clsx from "clsx";
-import { FC, useId } from "react";
+import { FC, useId, useState } from "react";
 
 import { WizStack } from "@/components";
 
@@ -29,6 +29,14 @@ export const Radio: FC<Props> = ({
   onChange,
 }: Props) => {
   const idPrefix = useId();
+  const [focusOption, setFocusOption] = useState<number | null>(null);
+
+  const radioLabelColor = (inputValue: number) => {
+    if (value === inputValue) return "checked";
+    if (focusOption === inputValue) return "focused";
+    return "default";
+  };
+
   return (
     <div className={styles.radioStyle}>
       <WizStack gap={gap} direction={direction} wrap>
@@ -39,6 +47,7 @@ export const Radio: FC<Props> = ({
           return (
             <div key={id}>
               <input
+                tabIndex={1}
                 className={styles.radioInputStyle}
                 type="radio"
                 id={id}
@@ -49,15 +58,21 @@ export const Radio: FC<Props> = ({
                 onClick={() => {
                   onChange?.(option.value);
                 }}
+                onFocus={(e) => {
+                  e.preventDefault();
+                  setFocusOption(option.value);
+                }}
+                onBlur={(e) => {
+                  e.preventDefault();
+                  setFocusOption(null);
+                }}
               />
               <label
                 className={clsx(
                   styles.radioLabelStyle,
                   isChecked && styles.radioLabelCheckedStyle,
                   isDisabled && styles.radioLabelDisabledStyle,
-                  styles.radioLabelColorStyle[
-                    isChecked ? "checked" : "default"
-                  ],
+                  styles.radioLabelColorStyle[radioLabelColor(option.value)],
                   styles.radioLabelCursorStyle[
                     isDisabled ? "disabled" : "default"
                   ],

--- a/packages/wiz-ui-react/src/components/base/inputs/radio/components/radio.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/radio/components/radio.tsx
@@ -47,7 +47,6 @@ export const Radio: FC<Props> = ({
           return (
             <div key={id}>
               <input
-                tabIndex={1}
                 className={styles.radioInputStyle}
                 type="radio"
                 id={id}
@@ -58,12 +57,10 @@ export const Radio: FC<Props> = ({
                 onClick={() => {
                   onChange?.(option.value);
                 }}
-                onFocus={(e) => {
-                  e.preventDefault();
+                onFocus={() => {
                   setFocusOption(option.value);
                 }}
-                onBlur={(e) => {
-                  e.preventDefault();
+                onBlur={() => {
                   setFocusOption(null);
                 }}
               />


### PR DESCRIPTION
# タスク

resolve: #957 

- Radio ボタンにフォーカスされたら矢印キーで選択できるようにする

