### PR TITLE
[#976] 左右のキーボードを押したときにスクロールがおまけで付いてくるバグの修正

### DIFF
--- a/.changeset/friendly-experts-doubt.md
+++ b/.changeset/friendly-experts-doubt.md
@@ -1,0 +1,6 @@
+---
+"@wizleap-inc/wiz-ui-next": patch
+"@wizleap-inc/wiz-ui": patch
+---
+
+[#976] 左右にスクロールするバグの修正

--- a/packages/wiz-ui-next/src/components/base/inputs/date-range-picker/date-range-picker.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/date-range-picker/date-range-picker.vue
@@ -250,13 +250,15 @@ const setIsHover = (value: boolean) => emit("update:isHover", value);
 const onClickCancel = () =>
   emit("update:modelValue", { start: null, end: null });
 
-const moveToNextMonth = () => {
+const moveToNextMonth = (e: KeyboardEvent | MouseEvent) => {
+  e.preventDefault();
   rightCalendarDate.value = new Date(
     rightCalendarDate.value.setMonth(rightCalendarDate.value.getMonth() + 1)
   );
 };
 
-const moveToPrevMonth = () => {
+const moveToPrevMonth = (e: KeyboardEvent | MouseEvent) => {
+  e.preventDefault();
   rightCalendarDate.value = leftCalendarDate.value;
 };
 

--- a/packages/wiz-ui/src/components/base/inputs/date-range-picker/date-range-picker.vue
+++ b/packages/wiz-ui/src/components/base/inputs/date-range-picker/date-range-picker.vue
@@ -243,13 +243,15 @@ const setIsOpen = (value: boolean) => emit("updateIsOpen", value);
 const setIsHover = (value: boolean) => emit("updateIsHover", value);
 const onClickCancel = () => emit("input", { start: null, end: null });
 
-const moveToNextMonth = () => {
+const moveToNextMonth = (e: KeyboardEvent | MouseEvent) => {
+  e.preventDefault();
   rightCalendarDate.value = new Date(
     rightCalendarDate.value.setMonth(rightCalendarDate.value.getMonth() + 1)
   );
 };
 
-const moveToPrevMonth = () => {
+const moveToPrevMonth = (e: KeyboardEvent | MouseEvent) => {
+  e.preventDefault();
   rightCalendarDate.value = leftCalendarDate.value;
 };
 


### PR DESCRIPTION
# タスク

resolve: #976

- e.preventDefault() を追加して左右にスクロールしないように修正した 

https://github.com/Wizleap-Inc/wiz-ui/assets/29594820/3392de1b-0540-4ba9-bd4f-8203b810fe13



<!-- reviewerにオーナーを追加してください-->
