### PR TITLE
Date Picker, Data Range Picker のキーボード対応追加 (React)

### DIFF
--- a/.changeset/breezy-seas-walk.md
+++ b/.changeset/breezy-seas-walk.md
@@ -1,0 +1,5 @@
+---
+"@wizleap-inc/wiz-ui-react": patch
+---
+
+[#965] DatePicker, DateRangePicker にキーボード操作追加 (React)

--- a/packages/wiz-ui-react/src/components/base/inputs/date-picker/components/date-picker.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/date-picker/components/date-picker.tsx
@@ -54,7 +54,7 @@ const DatePicker: FC<Props> = ({
     );
   };
 
-  const handleCalendar = (e: KeyboardEvent<HTMLButtonElement>) => {
+  const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
     e.preventDefault();
     switch (e.key) {
       case "ArrowUp":
@@ -105,7 +105,7 @@ const DatePicker: FC<Props> = ({
         onFocus={() => setIsFocused(true)}
         onBlur={() => setIsFocused(false)}
         onClick={() => setIsOpen((prev) => !prev)}
-        onKeyDown={handleCalendar}
+        onKeyDown={handleKeyDown}
       >
         <WizHStack gap="xs" align="center" height="100%">
           {cancelButtonVisible ? (

--- a/packages/wiz-ui-react/src/components/base/inputs/date-picker/components/date-picker.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/date-picker/components/date-picker.tsx
@@ -7,7 +7,7 @@ import {
 } from "@wizleap-inc/wiz-ui-styles/commons";
 import { formatDateToYYMMDD } from "@wizleap-inc/wiz-ui-utils";
 import clsx from "clsx";
-import { FC, useContext, useRef, useState } from "react";
+import { FC, KeyboardEvent, useContext, useRef, useState } from "react";
 
 import { WizCalendar, WizPopup, WizText } from "@/components";
 import { WizIcon } from "@/components/base/icon";
@@ -53,6 +53,23 @@ const DatePicker: FC<Props> = ({
       )
     );
   };
+
+  const handleCalendar = (e: KeyboardEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    switch (e.key) {
+      case "ArrowUp":
+        return moveCalendar(1, 0);
+      case "ArrowDown":
+        return moveCalendar(-1, 0);
+      case "ArrowRight":
+        return moveCalendar(0, 1);
+      case "ArrowLeft":
+        return moveCalendar(0, -1);
+      case "Enter":
+        return setIsOpen((prev) => !prev);
+    }
+  };
+
   const calendar = {
     title: `${currentMonth.getMonth() + 1}月`,
     year: currentMonth.getFullYear(),
@@ -88,6 +105,7 @@ const DatePicker: FC<Props> = ({
         onFocus={() => setIsFocused(true)}
         onBlur={() => setIsFocused(false)}
         onClick={() => setIsOpen((prev) => !prev)}
+        onKeyDown={handleCalendar}
       >
         <WizHStack gap="xs" align="center" height="100%">
           {cancelButtonVisible ? (

--- a/packages/wiz-ui-react/src/components/base/inputs/date-range-picker/components/date-range-picker.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/date-range-picker/components/date-range-picker.tsx
@@ -129,7 +129,7 @@ const DateRangePicker: FC<Props> = ({
       case "ArrowLeft":
         moveCalendar("prevMonth");
       case "Enter":
-        setIsOpen(true);
+        setIsOpen(!isOpen);
     }
   };
 
@@ -178,7 +178,7 @@ const DateRangePicker: FC<Props> = ({
       <button
         ref={anchor}
         aria-label={ARIA_LABELS.RANGE_DATE_PICKER_INPUT}
-        onClick={() => setIsOpen(true)}
+        onClick={() => setIsOpen(!isOpen)}
         onMouseEnter={() => setIsHover(true)}
         onMouseLeave={() => setIsHover(false)}
         onFocus={() => setIsFocused(true)}

--- a/packages/wiz-ui-react/src/components/base/inputs/date-range-picker/components/date-range-picker.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/date-range-picker/components/date-range-picker.tsx
@@ -3,7 +3,15 @@ import * as styles from "@wizleap-inc/wiz-ui-styles/bases/date-range-picker.css"
 import { inputBorderStyle } from "@wizleap-inc/wiz-ui-styles/commons";
 import { formatDateToYYMMDD } from "@wizleap-inc/wiz-ui-utils";
 import clsx from "clsx";
-import { FC, useCallback, useContext, useMemo, useRef, useState } from "react";
+import {
+  FC,
+  KeyboardEvent,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import {
   WizCalendar,
@@ -113,6 +121,18 @@ const DateRangePicker: FC<Props> = ({
     return [];
   }, [dateRange]);
 
+  const handleCalendar = (e: KeyboardEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    switch (e.key) {
+      case "ArrowRight":
+        moveCalendar("nextMonth");
+      case "ArrowLeft":
+        moveCalendar("prevMonth");
+      case "Enter":
+        setIsOpen(true);
+    }
+  };
+
   const onClickDate = useCallback(
     (date: Date) => {
       const [start, end] = [dateRange.start, dateRange.end];
@@ -163,6 +183,7 @@ const DateRangePicker: FC<Props> = ({
         onMouseLeave={() => setIsHover(false)}
         onFocus={() => setIsFocused(true)}
         onBlur={() => setIsFocused(false)}
+        onKeyDown={handleCalendar}
         disabled={disabled}
         className={clsx(
           styles.bodyStyle[disabled ? "disabled" : "active"],

--- a/packages/wiz-ui-react/src/components/base/inputs/date-range-picker/components/date-range-picker.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/date-range-picker/components/date-range-picker.tsx
@@ -121,15 +121,15 @@ const DateRangePicker: FC<Props> = ({
     return [];
   }, [dateRange]);
 
-  const handleCalendar = (e: KeyboardEvent<HTMLButtonElement>) => {
+  const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
     e.preventDefault();
     switch (e.key) {
       case "ArrowRight":
-        moveCalendar("nextMonth");
+        return moveCalendar("nextMonth");
       case "ArrowLeft":
-        moveCalendar("prevMonth");
+        return moveCalendar("prevMonth");
       case "Enter":
-        setIsOpen(!isOpen);
+        return setIsOpen(!isOpen);
     }
   };
 
@@ -183,7 +183,7 @@ const DateRangePicker: FC<Props> = ({
         onMouseLeave={() => setIsHover(false)}
         onFocus={() => setIsFocused(true)}
         onBlur={() => setIsFocused(false)}
-        onKeyDown={handleCalendar}
+        onKeyDown={handleKeyDown}
         disabled={disabled}
         className={clsx(
           styles.bodyStyle[disabled ? "disabled" : "active"],


### PR DESCRIPTION
# タスク

resolve: #965

- React のキーボード操作追加
- React の `date-range-picker` にて、onClick 時に true で開いたままになっていたのでこのバグを修正した

<!-- reviewerにオーナーを追加してください-->
