### PR TITLE
fix: button要素にtypeを付与

### DIFF
--- a/.eslintrc.react.json
+++ b/.eslintrc.react.json
@@ -10,6 +10,16 @@
     "react/jsx-uses-react": "off",
     "react/react-in-jsx-scope": "off",
     "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "warn"
-  }
+    "react-hooks/exhaustive-deps": "warn",
+    "react/button-has-type": "warn"
+  },
+  "overrides": [
+    {
+      "files": ["*.stories.tsx", "./**/stories/**/*.tsx"],
+      "rules": {
+        "react-hooks/rules-of-hooks": "off",
+        "react/button-has-type": "off"
+      }
+    }
+  ]
 }

--- a/packages/wiz-ui-react/src/components/base/buttons/.eslintrc.json
+++ b/packages/wiz-ui-react/src/components/base/buttons/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "react/button-has-type": "off"
+  }
+}

--- a/packages/wiz-ui-react/src/components/base/calendar/components/calendar.tsx
+++ b/packages/wiz-ui-react/src/components/base/calendar/components/calendar.tsx
@@ -84,6 +84,7 @@ const Calendar: FC<Props> = ({
                   className={styles.calendarCellStyle}
                 >
                   <button
+                    type="button"
                     disabled={item.isOutOfCurrentMonth}
                     aria-label={`${currentMonth.getFullYear()}年${
                       currentMonth.getMonth() + 1

--- a/packages/wiz-ui-react/src/components/base/dropdown/components/dropdown-item.tsx
+++ b/packages/wiz-ui-react/src/components/base/dropdown/components/dropdown-item.tsx
@@ -33,6 +33,7 @@ const DropdownItem: FC<Props> = ({
 
   return (
     <button
+      type="button"
       className={styles.dropdownItemStyle}
       disabled={disabled}
       onClick={onClick}

--- a/packages/wiz-ui-react/src/components/base/inputs/date-picker/components/date-picker.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/date-picker/components/date-picker.tsx
@@ -93,6 +93,7 @@ const DatePicker: FC<Props> = ({
         <WizHStack gap="xs" align="center" height="100%">
           {cancelButtonVisible ? (
             <button
+              type="button"
               className={styles.datePickerCancelButtonStyle}
               disabled={disabled}
               onClick={() => onChangeDate(null)}
@@ -102,6 +103,7 @@ const DatePicker: FC<Props> = ({
             </button>
           ) : (
             <button
+              type="button"
               className={styles.datePickerCancelButtonStyle}
               disabled={disabled}
             >
@@ -131,6 +133,7 @@ const DatePicker: FC<Props> = ({
               </WizText>
               <WizVStack>
                 <button
+                  type="button"
                   onClick={() => moveCalendar(1, 0)}
                   className={styles.datePickerYearSelectorItemStyle}
                   aria-label={ARIA_LABELS.YEAR_SELECTOR_NEXT}
@@ -152,6 +155,7 @@ const DatePicker: FC<Props> = ({
                   </svg>
                 </button>
                 <button
+                  type="button"
                   onClick={() => moveCalendar(-1, 0)}
                   className={styles.datePickerYearSelectorItemStyle}
                   aria-label={ARIA_LABELS.YEAR_SELECTOR_PREV}
@@ -179,6 +183,7 @@ const DatePicker: FC<Props> = ({
             </WizText>
             <div className={styles.datePickerMonthSelectorStyle}>
               <button
+                type="button"
                 aria-label={ARIA_LABELS.MONTH_SELECTOR_PREV}
                 onClick={() => moveCalendar(0, -1)}
                 className={styles.datePickerMonthSelectorItemStyle}
@@ -186,6 +191,7 @@ const DatePicker: FC<Props> = ({
                 <WizIcon size="md" color="inherit" icon={WizIChevronLeft} />
               </button>
               <button
+                type="button"
                 aria-label={ARIA_LABELS.MONTH_SELECTOR_NEXT}
                 onClick={() => moveCalendar(0, 1)}
                 className={styles.datePickerMonthSelectorItemStyle}

--- a/packages/wiz-ui-react/src/components/base/inputs/date-range-picker/components/date-range-picker.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/date-range-picker/components/date-range-picker.tsx
@@ -156,6 +156,7 @@ const DateRangePicker: FC<Props> = ({
   return (
     <>
       <button
+        type="button"
         ref={anchor}
         aria-label={ARIA_LABELS.RANGE_DATE_PICKER_INPUT}
         onClick={() => setIsOpen(true)}
@@ -172,6 +173,7 @@ const DateRangePicker: FC<Props> = ({
       >
         {cancelButtonVisible ? (
           <button
+            type="button"
             className={styles.popupCalendarCancelButtonStyle}
             disabled={disabled}
             onClick={onClickCancel}
@@ -181,6 +183,7 @@ const DateRangePicker: FC<Props> = ({
           </button>
         ) : (
           <button
+            type="button"
             className={styles.popupCalendarCancelButtonStyle}
             disabled={disabled}
           >
@@ -222,6 +225,7 @@ const DateRangePicker: FC<Props> = ({
                   ref={selectBoxRef}
                 >
                   <button
+                    type="button"
                     className={clsx(
                       styles.popupHeaderSelectBoxStyle,
                       inputBorderStyle[isSelectBoxOpen ? "active" : "default"]
@@ -239,6 +243,7 @@ const DateRangePicker: FC<Props> = ({
                       <div className={styles.popupHeaderSelectBoxOptionsStyle}>
                         {selectBoxOptions.map((option) => (
                           <button
+                            type="button"
                             key={option.value}
                             className={styles.popupHeaderSelectBoxOptionStyle}
                             aria-label={option.label}
@@ -259,6 +264,7 @@ const DateRangePicker: FC<Props> = ({
               <div className={styles.popupCalendarContainerStyle["left"]}>
                 <div className={styles.popupCalendarHeaderStyle}>
                   <button
+                    type="button"
                     className={styles.popupCalendarHeaderButtonStyle}
                     onClick={() => moveCalendar("prevMonth")}
                     aria-label={ARIA_LABELS.MONTH_SELECTOR_PREV}
@@ -287,6 +293,7 @@ const DateRangePicker: FC<Props> = ({
                     }月`}
                   </span>
                   <button
+                    type="button"
                     className={styles.popupCalendarHeaderButtonStyle}
                     onClick={() => moveCalendar("nextMonth")}
                     aria-label={ARIA_LABELS.MONTH_SELECTOR_NEXT}

--- a/packages/wiz-ui-react/src/components/base/inputs/password/components/password-input.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/password/components/password-input.tsx
@@ -66,6 +66,7 @@ const PasswordInput = forwardRef<HTMLInputElement, Props>(
           onChange={(e) => onChange(e.target.value)}
         />
         <button
+          type="button"
           aria-label={ARIA_LABELS.PASSWORD_VISIBLE_TOGGLE}
           className={styles.passwordVisibleIconStyle}
           onClick={() => setIsPasswordVisible(!isPasswordVisible)}

--- a/packages/wiz-ui-react/src/components/base/inputs/search-selector/components/search-selector.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-selector/components/search-selector.tsx
@@ -242,6 +242,7 @@ const SearchSelector: FC<Props> = ({
                   {selectedOption.label}
                 </span>
                 <button
+                  type="button"
                   ref={(ref) => (clearButtonsRef.current[i] = ref)}
                   className={styles.selectBoxInnerBoxCloseButtonStyle}
                   disabled={disabled}

--- a/packages/wiz-ui-react/src/components/base/inputs/time-picker/components/time-picker.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/time-picker/components/time-picker.tsx
@@ -99,6 +99,7 @@ const TimePicker = ({
         >
           <WizHStack gap="sm" align="center" height="100%">
             <button
+              type="button"
               className={clsx([
                 styles.cancelButtonStyle,
                 disabled && styles.cancelButtonDisabledStyle,

--- a/packages/wiz-ui-react/src/components/base/snackbar/components/snackbar.tsx
+++ b/packages/wiz-ui-react/src/components/base/snackbar/components/snackbar.tsx
@@ -67,6 +67,7 @@ const Snackbar: FC<Props> = ({
           </WizText>
         </div>
         <button
+          type="button"
           className={styles.snackbarCloseButtonStyle}
           onClick={handleClose}
         >

--- a/packages/wiz-ui-react/src/components/custom/chat/components/chat-card.tsx
+++ b/packages/wiz-ui-react/src/components/custom/chat/components/chat-card.tsx
@@ -245,6 +245,7 @@ const ChatCard: FC<Props> = ({
         </WizBox>
       </WizCard>
       <button
+        type="button"
         className={styles.chatCardOpenButtonStyle}
         onClick={handleClickToggleButton}
       />

--- a/packages/wiz-ui-react/src/components/custom/schedule/components/card.tsx
+++ b/packages/wiz-ui-react/src/components/custom/schedule/components/card.tsx
@@ -45,6 +45,7 @@ export const WizScheduleCard = ({
 
   return (
     <button
+      type="button"
       className={clsx(styles.card[variant], styles.buttonCard)}
       style={{ gridRow, gridColumn }}
       hidden={!show}


### PR DESCRIPTION
# 概要

button 要素は type を指定しなかったとき既定値で `type="submit"` となり、Form 要素内にある submit button が押下されると form が submit されてしまい UI ライブラリとしては具合が悪いので、button 要素に対する type 指定漏れを検知する lint ルールを追加し、対象となるコンポーネントに適用します。

ただし、以下のコンポーネントは lint ルールの対象外としています。
* `base/buttons` 配下のコンポーネント
  * これらのコンポーネントは Props で与えられた `type` を button 要素に受け渡すだけで、明示的に `type` を指定しないため
* Story 関連のファイル
  * 今回対象としたいのは公開するコンポーネントのみなため

また、各コンポーネントに付与する `type` として、`submit` を想定しているコンポーネントは存在しないと思われるので全て `type="button"` を指定しています。