### PR TITLE
fix(message-box): slotが空のときにタイトル下にmarginが入ってしまうのを解消

### DIFF
--- a/.changeset/thirty-lions-clean.md
+++ b/.changeset/thirty-lions-clean.md
@@ -1,0 +1,8 @@
+---
+"@wizleap-inc/wiz-ui-react": patch
+"@wizleap-inc/wiz-ui-next": patch
+"@wizleap-inc/wiz-ui-styles": patch
+"@wizleap-inc/wiz-ui": patch
+---
+
+fix(message-box): slot が空のときにタイトル下に margin が入ってしまうのを解消

--- a/packages/styles/bases/message-box.css.ts
+++ b/packages/styles/bases/message-box.css.ts
@@ -58,7 +58,6 @@ export const messageBoxTitleStyle = style({
   fontWeight: 700,
   fontSize: THEME.fontSize.sm,
   lineHeight: THEME.fontSize.xl2,
-  marginBottom: THEME.spacing.xs,
   color: THEME.color.gray[700],
   textAlign: "left",
 });

--- a/packages/wiz-ui-next/src/components/base/message-box/message-box.stories.ts
+++ b/packages/wiz-ui-next/src/components/base/message-box/message-box.stories.ts
@@ -68,3 +68,16 @@ ExpandWithIcon.args = {
   expand: true,
   icon: WizIClose,
 };
+
+const EmptyTemplate: StoryFn<typeof WizMessageBox> = (args) => ({
+  components: { WizMessageBox, WizText },
+  setup: () => ({ args }),
+  template: `
+    <WizMessageBox v-bind="args" />
+  `,
+});
+export const EmptyBody = EmptyTemplate.bind({});
+EmptyBody.args = {
+  title: "ヘッダーヘッダーヘッダー",
+  variant: "information",
+};

--- a/packages/wiz-ui-next/src/components/base/message-box/message-box.vue
+++ b/packages/wiz-ui-next/src/components/base/message-box/message-box.vue
@@ -11,10 +11,12 @@
       :is="icon"
       :class="[messageBoxIconStyle, messageBoxIconFillStyle[variant]]"
     />
-    <div>
+    <WizVStack gap="xs">
       <div :class="messageBoxTitleStyle">{{ title }}</div>
-      <slot></slot>
-    </div>
+      <div v-if="hasDefaultSlot">
+        <slot />
+      </div>
+    </WizVStack>
   </div>
 </template>
 
@@ -28,8 +30,9 @@ import {
   messageBoxIconFillStyle,
   messageBoxTitleStyle,
 } from "@wizleap-inc/wiz-ui-styles/bases/message-box.css";
-import { computed, PropType } from "vue";
+import { computed, PropType, useSlots } from "vue";
 
+import { WizVStack } from "@/components";
 import type { TIcon } from "@/components/icons";
 
 defineOptions({
@@ -60,4 +63,7 @@ const props = defineProps({
 const computedWidth = computed(() => {
   return props.expand ? "expand" : "default";
 });
+
+const slots = useSlots();
+const hasDefaultSlot = slots.default ? !!slots.default() : false;
 </script>

--- a/packages/wiz-ui-react/src/components/base/message-box/components/message-box.tsx
+++ b/packages/wiz-ui-react/src/components/base/message-box/components/message-box.tsx
@@ -3,7 +3,7 @@ import * as styles from "@wizleap-inc/wiz-ui-styles/bases/message-box.css";
 import clsx from "clsx";
 import { ForwardedRef, ReactNode, forwardRef } from "react";
 
-import { TIcon, WizIcon } from "@/components";
+import { TIcon, WizIcon, WizVStack } from "@/components";
 
 const iconFontColor: Record<string, ColorKeys> = {
   information: "green.800",
@@ -40,8 +40,10 @@ const MessageBox = forwardRef(
           </div>
         )}
         <div>
-          <div className={styles.messageBoxTitleStyle}>{title}</div>
-          {children}
+          <WizVStack gap="xs">
+            <div className={styles.messageBoxTitleStyle}>{title}</div>
+            {children && <div>{children}</div>}
+          </WizVStack>
         </div>
       </div>
     );

--- a/packages/wiz-ui-react/src/components/base/message-box/stories/message-box.stories.tsx
+++ b/packages/wiz-ui-react/src/components/base/message-box/stories/message-box.stories.tsx
@@ -82,3 +82,11 @@ export const WithIcon: Story = {
     </WizMessageBox>
   ),
 };
+
+export const EmptyBody: Story = {
+  args: {
+    title: "ヘッダーヘッダーヘッダー",
+    variant: "information",
+  },
+  render: (args) => <WizMessageBox {...args} />,
+};

--- a/packages/wiz-ui/src/components/base/message-box/message-box.stories.ts
+++ b/packages/wiz-ui/src/components/base/message-box/message-box.stories.ts
@@ -68,3 +68,14 @@ ExpandWithIcon.args = {
   expand: true,
   icon: WizIClose,
 };
+
+const EmptyTemplate: StoryFn = (_, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { WizMessageBox, WizText },
+  template: `<WizMessageBox v-bind="$props" />`,
+});
+export const EmptyBody = EmptyTemplate.bind({});
+EmptyBody.args = {
+  title: "ヘッダーヘッダーヘッダー",
+  variant: "information",
+};

--- a/packages/wiz-ui/src/components/base/message-box/message-box.vue
+++ b/packages/wiz-ui/src/components/base/message-box/message-box.vue
@@ -11,10 +11,12 @@
       :is="icon"
       :class="[messageBoxIconStyle, messageBoxIconFillStyle[variant]]"
     />
-    <div>
+    <WizVStack gap="xs">
       <div :class="messageBoxTitleStyle">{{ title }}</div>
-      <slot></slot>
-    </div>
+      <div v-if="hasDefaultSlot">
+        <slot />
+      </div>
+    </WizVStack>
   </div>
 </template>
 
@@ -28,8 +30,9 @@ import {
   messageBoxIconFillStyle,
   messageBoxTitleStyle,
 } from "@wizleap-inc/wiz-ui-styles/bases/message-box.css";
-import { computed, PropType } from "vue";
+import { computed, PropType, useSlots } from "vue";
 
+import { WizVStack } from "@/components";
 import type { TIcon } from "@/components/icons";
 
 defineOptions({
@@ -60,4 +63,7 @@ const props = defineProps({
 const computedWidth = computed(() => {
   return props.expand ? "expand" : "default";
 });
+
+const slots = useSlots();
+const hasDefaultSlot = slots.default ? !!slots.default() : false;
 </script>


### PR DESCRIPTION
# タスク

resolve: https://github.com/Wizleap-Inc/wiz-ui/issues/997

<!-- reviewerにオーナーを追加してください-->
