### PR TITLE
WizCheckBoxNew コンポーネントを追加

### DIFF
--- a/.changeset/olive-dingos-jam.md
+++ b/.changeset/olive-dingos-jam.md
@@ -1,0 +1,8 @@
+---
+"@wizleap-inc/wiz-ui-react": minor
+"@wizleap-inc/wiz-ui-next": minor
+"@wizleap-inc/wiz-ui-constants": minor
+"@wizleap-inc/wiz-ui-styles": minor
+---
+
+WizCheckBoxNew を追加

--- a/packages/constants/component/name.ts
+++ b/packages/constants/component/name.ts
@@ -23,6 +23,7 @@ export const ComponentName = {
   TextInput: "WizTextInput",
   BaseInput: "WizBaseInput",
   CheckBox: "WizCheckBox",
+  CheckBoxNew: "WizCheckBoxNew",
   Radio: "WizRadio",
   TimePicker: "WizTimePicker",
   Tab: "WizTab",

--- a/packages/styles/bases/checkbox-new.css.ts
+++ b/packages/styles/bases/checkbox-new.css.ts
@@ -103,8 +103,8 @@ export const iconWrapperStyle = style([
       [`${inputStyle}:checked:not(:disabled) + &`]: {
         backgroundColor: THEME.color.green[800],
       },
-      [`${borderedBaseStyle} > &`]: {
-        backgroundColor: "transparent",
+      [`${inputStyle}:disabled + &`]: {
+        backgroundColor: THEME.color.gray[300],
       },
       [`${inputStyle}:checked:disabled + &`]: {
         backgroundColor: THEME.color.gray[400],

--- a/packages/styles/bases/checkbox-new.css.ts
+++ b/packages/styles/bases/checkbox-new.css.ts
@@ -1,0 +1,105 @@
+import { style, styleVariants } from "@vanilla-extract/css";
+import { THEME } from "@wizleap-inc/wiz-ui-constants";
+
+const labelBaseStyle = style({
+  display: "inline-flex",
+  alignItems: "center",
+  gap: THEME.spacing.xs,
+  fontSize: THEME.fontSize.sm,
+});
+
+export const labelStyle = styleVariants({
+  default: [
+    labelBaseStyle,
+    {
+      color: THEME.color.gray[800],
+      cursor: "pointer",
+    },
+  ],
+  disabled: [
+    labelBaseStyle,
+    {
+      color: THEME.color.gray[500],
+      cursor: "not-allowed",
+    },
+  ],
+});
+
+export const strikeThroughStyle = style({
+  textDecorationLine: "line-through",
+});
+
+const borderedBaseStyle = style({
+  borderWidth: "1px",
+  borderStyle: "solid",
+  borderRadius: "4px",
+  paddingBlock: THEME.spacing.xs,
+  paddingInline: THEME.spacing.md,
+});
+
+export const borderedStyle = styleVariants({
+  default: [
+    borderedBaseStyle,
+    {
+      borderColor: THEME.color.gray[400],
+    },
+  ],
+  checked: [
+    borderedBaseStyle,
+    {
+      borderColor: THEME.color.green[800],
+    },
+  ],
+  error: [
+    borderedBaseStyle,
+    {
+      borderColor: THEME.color.red[800],
+    },
+  ],
+  disabled: [
+    borderedBaseStyle,
+    {
+      borderColor: THEME.color.gray[400],
+      backgroundColor: THEME.color.gray[300],
+    },
+  ],
+});
+
+const inputShapeStyle = style({
+  height: THEME.fontSize.md,
+  width: THEME.fontSize.md,
+  borderRadius: "2px",
+});
+
+export const inputStyle = style([
+  inputShapeStyle,
+  {
+    position: "absolute",
+    WebkitAppearance: "none",
+    MozAppearance: "none",
+    appearance: "none",
+    margin: 0,
+    padding: 0,
+  },
+]);
+
+export const iconWrapperStyle = style([
+  inputShapeStyle,
+  {
+    height: THEME.fontSize.md,
+    width: THEME.fontSize.md,
+    borderRadius: "2px",
+    boxSizing: "border-box",
+    selectors: {
+      [`${inputStyle}:not(:checked) + &`]: {
+        border: `1px solid ${THEME.color.gray[500]}`,
+      },
+      [`${inputStyle}:checked:not(:disabled) + &`]: {
+        backgroundColor: THEME.color.green[800],
+      },
+      [`${inputStyle}:checked:disabled + &`]: {
+        backgroundColor: THEME.color.gray[400],
+      },
+    },
+  },
+]);

--- a/packages/styles/bases/checkbox-new.css.ts
+++ b/packages/styles/bases/checkbox-new.css.ts
@@ -35,6 +35,7 @@ const borderedBaseStyle = style({
   borderRadius: "4px",
   paddingBlock: THEME.spacing.xs,
   paddingInline: THEME.spacing.md,
+  lineHeight: THEME.fontSize.xl2,
 });
 
 export const borderedStyle = styleVariants({

--- a/packages/styles/bases/checkbox-new.css.ts
+++ b/packages/styles/bases/checkbox-new.css.ts
@@ -29,13 +29,15 @@ export const strikeThroughStyle = style({
   textDecorationLine: "line-through",
 });
 
+const borderedBorderWidth = 1;
+
 const borderedBaseStyle = style({
-  borderWidth: "1px",
+  borderWidth: `${borderedBorderWidth}px`,
   borderStyle: "solid",
   borderRadius: "4px",
   paddingBlock: THEME.spacing.xs,
   paddingInline: THEME.spacing.md,
-  lineHeight: THEME.fontSize.xl2,
+  lineHeight: `calc(${THEME.fontSize.xl2} - (${borderedBorderWidth}px * 2))`,
 });
 
 export const borderedStyle = styleVariants({

--- a/packages/styles/bases/checkbox-new.css.ts
+++ b/packages/styles/bases/checkbox-new.css.ts
@@ -87,6 +87,7 @@ export const inputStyle = style([
 export const iconWrapperStyle = style([
   inputShapeStyle,
   {
+    position: "relative",
     height: THEME.fontSize.md,
     width: THEME.fontSize.md,
     borderRadius: "2px",
@@ -104,3 +105,10 @@ export const iconWrapperStyle = style([
     },
   },
 ]);
+
+export const iconPositionStyle = style({
+  position: "absolute",
+  top: "50%",
+  left: "50%",
+  transform: "translate(-50%, -50%)",
+});

--- a/packages/styles/bases/checkbox-new.css.ts
+++ b/packages/styles/bases/checkbox-new.css.ts
@@ -38,6 +38,7 @@ const borderedBaseStyle = style({
   paddingBlock: THEME.spacing.xs,
   paddingInline: THEME.spacing.md,
   lineHeight: `calc(${THEME.fontSize.xl2} - (${borderedBorderWidth}px * 2))`,
+  backgroundColor: THEME.color.white[800],
 });
 
 export const borderedStyle = styleVariants({
@@ -94,12 +95,16 @@ export const iconWrapperStyle = style([
     width: THEME.fontSize.md,
     borderRadius: "2px",
     boxSizing: "border-box",
+    backgroundColor: THEME.color.white[800],
     selectors: {
       [`${inputStyle}:not(:checked) + &`]: {
         border: `1px solid ${THEME.color.gray[500]}`,
       },
       [`${inputStyle}:checked:not(:disabled) + &`]: {
         backgroundColor: THEME.color.green[800],
+      },
+      [`${borderedBaseStyle} > &`]: {
+        backgroundColor: "transparent",
       },
       [`${inputStyle}:checked:disabled + &`]: {
         backgroundColor: THEME.color.gray[400],

--- a/packages/wiz-ui-next/src/components/base/inputs/checkbox-new/checkbox-new.stories.ts
+++ b/packages/wiz-ui-next/src/components/base/inputs/checkbox-new/checkbox-new.stories.ts
@@ -1,0 +1,86 @@
+import { StoryFn, Meta } from "@storybook/vue3";
+
+import { WizVStack, WizHStack } from "@/components";
+
+import { WizCheckBoxNew } from ".";
+
+export default {
+  title: "Base/Input/CheckBoxNew",
+  component: WizCheckBoxNew,
+  argTypes: {
+    checked: {
+      control: { type: "boolean" },
+    },
+    value: {
+      control: { type: "object" },
+    },
+    id: {
+      control: { type: "string" },
+    },
+    name: {
+      control: { type: "string" },
+    },
+    disabled: {
+      control: { type: "boolean" },
+    },
+    strikeThrough: {
+      control: { type: "boolean" },
+    },
+    bordered: {
+      control: { type: "boolean" },
+    },
+    error: {
+      control: { type: "boolean" },
+    },
+  },
+} as Meta<typeof WizCheckBoxNew>;
+
+type Story = StoryFn<typeof WizCheckBoxNew>;
+
+export const Default: Story = () => ({
+  components: { WizCheckBoxNew },
+  template: `
+    <WizCheckBoxNew>Label</WizCheckBoxNew>
+  `,
+});
+
+export const Variations: Story = () => ({
+  components: { WizCheckBoxNew, WizVStack, WizHStack },
+  setup() {
+    return {
+      variations: [
+        [
+          { checked: false },
+          { checked: false, disabled: true },
+          { checked: false, strikeThrough: true },
+        ],
+        [
+          { checked: true },
+          { checked: true, disabled: true },
+          { checked: true, strikeThrough: true },
+        ],
+        [
+          { checked: false, bordered: true },
+          { checked: false, bordered: true, disabled: true },
+          { checked: false, bordered: true, error: true },
+          { checked: false, bordered: true, strikeThrough: true },
+        ],
+        [
+          { checked: true, bordered: true },
+          { checked: true, bordered: true, disabled: true },
+          { checked: true, bordered: true, error: true },
+          { checked: true, bordered: true, strikeThrough: true },
+        ],
+      ],
+    };
+  },
+  template: `
+    <WizVStack gap="md">
+      <WizHStack v-for="row in variations" gap="xl">
+        <template v-for="props in row">
+          <WizCheckBoxNew v-bind="props">Label</WizCheckBoxNew>
+        </template>
+      </WizHStack>
+    </WizVStack>
+  `,
+});

--- a/packages/wiz-ui-next/src/components/base/inputs/checkbox-new/checkbox-new.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/checkbox-new/checkbox-new.vue
@@ -25,7 +25,7 @@ import { WizICheckBold, WizIcon } from "@/components";
 
 interface Props {
   checked: boolean;
-  value?: string | number;
+  value?: string | number | string[];
   id?: string;
   name?: string;
   disabled?: boolean;

--- a/packages/wiz-ui-next/src/components/base/inputs/checkbox-new/checkbox-new.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/checkbox-new/checkbox-new.vue
@@ -1,0 +1,69 @@
+<template>
+  <label :class="labelClass">
+    <input
+      type="checkbox"
+      :class="styles.inputStyle"
+      :checked="checked"
+      :value="value"
+      :id="id"
+      :name="name"
+      :disabled="disabled"
+      @change="handleChange"
+    />
+    <span :class="styles.iconWrapperStyle">
+      <WizIcon :icon="WizICheckBold" color="white.800" size="md" />
+    </span>
+    <slot />
+  </label>
+</template>
+
+<script setup lang="ts">
+import * as styles from "@wizleap-inc/wiz-ui-styles/bases/checkbox-new.css";
+import { computed } from "vue";
+
+import { WizICheckBold, WizIcon } from "@/components";
+
+interface Props {
+  checked: boolean;
+  value?: string | number;
+  id?: string;
+  name?: string;
+  disabled?: boolean;
+  strikeThrough?: boolean;
+  bordered?: boolean;
+  error?: boolean;
+}
+const props = defineProps<Props>();
+
+interface Emits {
+  (e: "update:checked", checked: boolean): void;
+}
+const emit = defineEmits<Emits>();
+
+const labelClass = computed(() => {
+  const borderedState = (() => {
+    if (props.disabled) {
+      return "disabled";
+    }
+    if (props.error) {
+      return "error";
+    }
+    if (props.checked) {
+      return "checked";
+    }
+    return "default";
+  })();
+
+  return [
+    styles.labelStyle[props.disabled ? "disabled" : "default"],
+    props.strikeThrough && styles.strikeThroughStyle,
+    props.bordered && styles.borderedStyle[borderedState],
+  ];
+});
+
+const handleChange = (e: Event) => {
+  if (e.target instanceof HTMLInputElement) {
+    emit("update:checked", e.target.checked);
+  }
+};
+</script>

--- a/packages/wiz-ui-next/src/components/base/inputs/checkbox-new/checkbox-new.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/checkbox-new/checkbox-new.vue
@@ -3,7 +3,7 @@
     <input
       type="checkbox"
       :class="styles.inputStyle"
-      :checked="checked"
+      :checked="actualChecked"
       :value="value"
       :id="id"
       :name="name"
@@ -19,7 +19,7 @@
 
 <script setup lang="ts">
 import * as styles from "@wizleap-inc/wiz-ui-styles/bases/checkbox-new.css";
-import { computed } from "vue";
+import { computed, ref, watch } from "vue";
 
 import { WizICheckBold, WizIcon } from "@/components";
 
@@ -40,6 +40,15 @@ interface Emits {
 }
 const emit = defineEmits<Emits>();
 
+const actualChecked = ref(props.checked);
+
+watch(
+  () => props.checked,
+  () => {
+    actualChecked.value = props.checked;
+  }
+);
+
 const labelClass = computed(() => {
   const borderedState = (() => {
     if (props.disabled) {
@@ -48,7 +57,7 @@ const labelClass = computed(() => {
     if (props.error) {
       return "error";
     }
-    if (props.checked) {
+    if (actualChecked.value) {
       return "checked";
     }
     return "default";
@@ -64,6 +73,7 @@ const labelClass = computed(() => {
 const handleChange = (e: Event) => {
   if (e.target instanceof HTMLInputElement) {
     emit("update:checked", e.target.checked);
+    actualChecked.value = e.target.checked;
   }
 };
 </script>

--- a/packages/wiz-ui-next/src/components/base/inputs/checkbox-new/checkbox-new.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/checkbox-new/checkbox-new.vue
@@ -10,9 +10,11 @@
       :disabled="disabled"
       @change="handleChange"
     />
-    <span :class="styles.iconWrapperStyle">
-      <WizIcon :icon="WizICheckBold" color="white.800" size="md" />
-    </span>
+    <div :class="styles.iconWrapperStyle">
+      <div :class="styles.iconPositionStyle">
+        <WizIcon :icon="WizICheckBold" color="white.800" size="md" />
+      </div>
+    </div>
     <slot />
   </label>
 </template>

--- a/packages/wiz-ui-next/src/components/base/inputs/checkbox-new/index.ts
+++ b/packages/wiz-ui-next/src/components/base/inputs/checkbox-new/index.ts
@@ -1,0 +1,1 @@
+export { default as WizCheckBoxNew } from "./checkbox-new.vue";

--- a/packages/wiz-ui-next/src/components/base/inputs/checkbox/index.ts
+++ b/packages/wiz-ui-next/src/components/base/inputs/checkbox/index.ts
@@ -1,1 +1,1 @@
-export { default as WizCheckBox } from "./checkbox.vue";
+export { /** @deprecated */ default as WizCheckBox } from "./checkbox.vue";

--- a/packages/wiz-ui-next/src/components/base/inputs/index.ts
+++ b/packages/wiz-ui-next/src/components/base/inputs/index.ts
@@ -1,5 +1,6 @@
 export * from "./text";
 export * from "./checkbox";
+export * from "./checkbox-new";
 export * from "./password";
 export * from "./search-selector";
 export * from "./selectbox";

--- a/packages/wiz-ui-react/src/components/base/inputs/checkbox-new/components/checkbox-new.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/checkbox-new/components/checkbox-new.tsx
@@ -86,9 +86,11 @@ const CheckboxNew = forwardRef<HTMLInputElement, Props>(
           checked={actualChecked}
           onChange={handleChange}
         />
-        <span className={styles.iconWrapperStyle}>
-          <WizIcon icon={WizICheckBold} color="white.800" size="md" />
-        </span>
+        <div className={styles.iconWrapperStyle}>
+          <div className={styles.iconPositionStyle}>
+            <WizIcon icon={WizICheckBold} color="white.800" size="md" />
+          </div>
+        </div>
         {children}
       </label>
     );

--- a/packages/wiz-ui-react/src/components/base/inputs/checkbox-new/components/checkbox-new.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/checkbox-new/components/checkbox-new.tsx
@@ -87,9 +87,11 @@ const CheckboxNew = forwardRef<HTMLInputElement, Props>(
           onChange={handleChange}
         />
         <div className={styles.iconWrapperStyle}>
-          <div className={styles.iconPositionStyle}>
-            <WizIcon icon={WizICheckBold} color="white.800" size="md" />
-          </div>
+          {actualChecked && (
+            <div className={styles.iconPositionStyle}>
+              <WizIcon icon={WizICheckBold} color="white.800" size="md" />
+            </div>
+          )}
         </div>
         {children}
       </label>

--- a/packages/wiz-ui-react/src/components/base/inputs/checkbox-new/components/checkbox-new.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/checkbox-new/components/checkbox-new.tsx
@@ -1,0 +1,100 @@
+import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
+import * as styles from "@wizleap-inc/wiz-ui-styles/bases/checkbox-new.css";
+import clsx from "clsx";
+import {
+  ChangeEvent,
+  ChangeEventHandler,
+  ComponentProps,
+  ReactNode,
+  forwardRef,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+import { WizIcon } from "@/components/base/icon";
+import { WizICheckBold } from "@/components/icons";
+
+type InputProps = ComponentProps<"input">;
+
+type Props = {
+  checked?: boolean;
+  value?: InputProps["value"];
+  id?: string;
+  name?: string;
+  disabled?: boolean;
+  strikeThrough?: boolean;
+  bordered?: boolean;
+  error?: boolean;
+  children?: ReactNode;
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
+};
+
+const CheckboxNew = forwardRef<HTMLInputElement, Props>(
+  (
+    { checked, children, strikeThrough, bordered, error, onChange, ...props },
+    ref
+  ) => {
+    const isControlled = checked !== undefined;
+
+    const [actualChecked, setActualChecked] = useState(checked);
+    useEffect(() => {
+      if (isControlled) {
+        setActualChecked(checked);
+      }
+    }, [checked, isControlled]);
+
+    const handleChange = useCallback<ChangeEventHandler<HTMLInputElement>>(
+      (e) => {
+        onChange?.(e);
+        if (!isControlled) {
+          setActualChecked(e.target.checked);
+        }
+      },
+      [isControlled, onChange]
+    );
+
+    const labelClassName = useMemo(() => {
+      const borderedState = (() => {
+        if (props.disabled) {
+          return "disabled";
+        }
+        if (error) {
+          return "error";
+        }
+        if (actualChecked) {
+          return "checked";
+        }
+        return "default";
+      })();
+
+      return clsx(
+        styles.labelStyle[props.disabled ? "disabled" : "default"],
+        strikeThrough && styles.strikeThroughStyle,
+        bordered && styles.borderedStyle[borderedState]
+      );
+    }, [actualChecked, bordered, error, props.disabled, strikeThrough]);
+
+    return (
+      <label className={labelClassName}>
+        <input
+          {...props}
+          ref={ref}
+          type="checkbox"
+          className={styles.inputStyle}
+          checked={actualChecked}
+          onChange={handleChange}
+        />
+        <span className={styles.iconWrapperStyle}>
+          <WizIcon icon={WizICheckBold} color="white.800" size="md" />
+        </span>
+        {children}
+      </label>
+    );
+  }
+);
+
+CheckboxNew.displayName = ComponentName.CheckBoxNew;
+
+export const WizCheckBoxNew = CheckboxNew;

--- a/packages/wiz-ui-react/src/components/base/inputs/checkbox-new/components/index.ts
+++ b/packages/wiz-ui-react/src/components/base/inputs/checkbox-new/components/index.ts
@@ -1,0 +1,1 @@
+export { WizCheckBoxNew } from "./checkbox-new";

--- a/packages/wiz-ui-react/src/components/base/inputs/checkbox-new/index.ts
+++ b/packages/wiz-ui-react/src/components/base/inputs/checkbox-new/index.ts
@@ -1,0 +1,1 @@
+export * from "./components";

--- a/packages/wiz-ui-react/src/components/base/inputs/checkbox-new/stories/checkbox-new.stories.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/checkbox-new/stories/checkbox-new.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { ComponentProps, useState } from "react";
+import { ComponentProps } from "react";
 
 import { WizHStack, WizVStack } from "@/components/base/stack";
 
@@ -16,16 +16,6 @@ type Story = StoryObj<typeof WizCheckBoxNew>;
 export const Default: Story = {
   args: {
     children: "Label",
-  },
-  render: (args) => {
-    const [checked, setChecked] = useState(false);
-    return (
-      <WizCheckBoxNew
-        {...args}
-        checked={checked}
-        onChange={(e) => setChecked(e.target.checked)}
-      />
-    );
   },
 };
 

--- a/packages/wiz-ui-react/src/components/base/inputs/checkbox-new/stories/checkbox-new.stories.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/checkbox-new/stories/checkbox-new.stories.tsx
@@ -1,0 +1,77 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { ComponentProps, useState } from "react";
+
+import { WizHStack, WizVStack } from "@/components/base/stack";
+
+import { WizCheckBoxNew } from "../components";
+
+const meta: Meta<typeof WizCheckBoxNew> = {
+  title: "Base/Input/CheckBoxNew",
+  component: WizCheckBoxNew,
+};
+
+export default meta;
+type Story = StoryObj<typeof WizCheckBoxNew>;
+
+export const Default: Story = {
+  args: {
+    children: "Label",
+  },
+  render: (args) => {
+    const [checked, setChecked] = useState(false);
+    return (
+      <WizCheckBoxNew
+        {...args}
+        checked={checked}
+        onChange={(e) => setChecked(e.target.checked)}
+      />
+    );
+  },
+};
+
+export const Variations: Story = {
+  render: () => {
+    const variations: ComponentProps<typeof WizCheckBoxNew>[][] = [
+      [
+        { checked: false },
+        { checked: false, disabled: true },
+        { checked: false, strikeThrough: true },
+      ],
+      [
+        { checked: true },
+        { checked: true, disabled: true },
+        { checked: true, strikeThrough: true },
+      ],
+      [
+        { checked: false, bordered: true },
+        { checked: false, bordered: true, disabled: true },
+        { checked: false, bordered: true, error: true },
+        { checked: false, bordered: true, strikeThrough: true },
+      ],
+      [
+        { checked: true, bordered: true },
+        { checked: true, bordered: true, disabled: true },
+        { checked: true, bordered: true, error: true },
+        { checked: true, bordered: true, strikeThrough: true },
+      ],
+    ];
+    return (
+      <WizVStack gap="md">
+        {variations.map((row, i) => (
+          <WizHStack gap="xl" key={i}>
+            {row.map((props, j) => (
+              <WizCheckBoxNew {...props} key={j}>
+                Label
+              </WizCheckBoxNew>
+            ))}
+          </WizHStack>
+        ))}
+      </WizVStack>
+    );
+  },
+  parameters: {
+    controls: {
+      disabled: true,
+    },
+  },
+};

--- a/packages/wiz-ui-react/src/components/base/inputs/checkbox/components/checkbox.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/checkbox/components/checkbox.tsx
@@ -111,4 +111,7 @@ const CheckBox: FC<Props> = ({
 
 CheckBox.displayName = ComponentName.CheckBox;
 
+/**
+ * @deprecated このコンポーネントは削除予定です。代わりに `CheckBoxNew` コンポーネントを使用してください
+ */
 export const WizCheckBox = CheckBox;

--- a/packages/wiz-ui-react/src/components/base/inputs/index.ts
+++ b/packages/wiz-ui-react/src/components/base/inputs/index.ts
@@ -1,4 +1,5 @@
 export * from "./checkbox";
+export * from "./checkbox-new";
 export * from "./radio";
 export * from "./search-input";
 export * from "./search-selector";


### PR DESCRIPTION
# タスク

resolve: #1027 


* 新しいチェックボックを `WizCheckBoxNew` として追加
  * コンポーネントとしてはグループ化されている必要はないので単体のチェックボックスとして実装
* 既存の `WizCheckBox` を deprecated
  * Vue 版はやり方が不明だったので React 版のみ