### PR TITLE
React / WizDateRangePickerでエラーの解消

### DIFF
--- a/packages/wiz-ui-react/src/components/base/inputs/date-range-picker/components/date-range-picker.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/date-range-picker/components/date-range-picker.tsx
@@ -198,23 +198,23 @@ const DateRangePicker: FC<Props> = ({
         )}
       >
         {cancelButtonVisible ? (
-          <button
-            type="button"
+          <div
+            role="button"
             className={styles.popupCalendarCancelButtonStyle}
-            disabled={disabled}
-            onClick={onClickCancel}
+            onClick={!disabled && onClickCancel}
             aria-label={ARIA_LABELS.DATE_PICKER_CANCEL}
+            onKeyDown={(event) => {
+              if (!disabled && (event.key === "Enter" || event.key === " ")) {
+                onClickCancel();
+              }
+            }}
           >
             <WizIcon size="xl2" color="inherit" icon={WizICancel} />
-          </button>
+          </div>
         ) : (
-          <button
-            type="button"
-            className={styles.popupCalendarCancelButtonStyle}
-            disabled={disabled}
-          >
+          <div role="button" className={styles.popupCalendarCancelButtonStyle}>
             <WizIcon size="xl2" color="gray.500" icon={WizICalendar} />
-          </button>
+          </div>
         )}
         <span
           className={


### PR DESCRIPTION
# タスク

resolve: #1140

このエラーの原因は、button タグに button タグを書いていたことが原因でした。
そのため、button タグを div タグに置き換えて修正を行い、バグが解消されていることが確認できた

![スクリーンショット 2023-12-05 22 11 44](https://github.com/Wizleap-Inc/wiz-ui/assets/29594820/9588bfd6-f8e6-42e0-b00f-c205d0d7c854)


<!-- reviewerにオーナーを追加してください-->
