### PR TITLE
Fix(timeline): アイテムを繋ぐ線が、背景より奥にある問題を修正

### DIFF
--- a/.changeset/loud-otters-perform.md
+++ b/.changeset/loud-otters-perform.md
@@ -1,0 +1,5 @@
+---
+"@wizleap-inc/wiz-ui-styles": minor
+---
+
+Fix(timeline): item を繋ぐ線が表示されないことがある問題を修正

--- a/packages/styles/customs/timeline.css.ts
+++ b/packages/styles/customs/timeline.css.ts
@@ -59,7 +59,6 @@ globalStyle(
     transform: "translateX(-50%)",
     height: `calc(100% + ${THEME.spacing[TIMELINES_GAP]})`,
     backgroundColor: THEME.color.gray[300],
-    zIndex: -1,
   }
 );
 
@@ -72,6 +71,7 @@ export const icon = style({
   justifyContent: "center",
   borderRadius: "50%",
   padding: timelineItemVars.iconPadding,
+  zIndex: 1,
 });
 
 export const iconVariant = styleVariants({


### PR DESCRIPTION
# タスク

resolve: #1164

次のようにして、アイコンを線より手前に表示することで修正
- 線のz-index設定を削除
- アイコンのz-indexを1

<!-- reviewerにオーナーを追加してください-->
