### PR TITLE
(Vue, React) base-inputを内部で使っているコンポーネントから、ComponentProps<"input">のプロパティを公開する 

### DIFF
--- a/.changeset/slow-insects-enjoy.md
+++ b/.changeset/slow-insects-enjoy.md
@@ -1,0 +1,6 @@
+---
+"@wizleap-inc/wiz-ui-react": patch
+"@wizleap-inc/wiz-ui-next": patch
+---
+
+[#1184] base-input の focusin, focusout の Event を受け取れるように修正

--- a/packages/wiz-ui-next/src/components/base/inputs/base/base.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/base/base.vue
@@ -106,7 +106,7 @@ const onFocusIn = (e: FocusEvent) => {
   emit("focusin", e);
 };
 const onFocusOut = (e: FocusEvent) => {
-  hasFocus.value = true;
+  hasFocus.value = false;
   emit("focusout", e);
 };
 </script>

--- a/packages/wiz-ui-next/src/components/base/inputs/base/base.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/base/base.vue
@@ -80,8 +80,8 @@ const props = defineProps({
 
 interface Emit {
   (e: "update:modelValue", value: string): void;
-  (e: "focusin"): void;
-  (e: "focusout"): void;
+  (e: "focusin", value: FocusEvent): void;
+  (e: "focusout", value: FocusEvent): void;
 }
 
 const emit = defineEmits<Emit>();
@@ -101,12 +101,12 @@ const state = computed(() => {
   return "default";
 });
 
-const onFocusIn = () => {
+const onFocusIn = (e: FocusEvent) => {
   hasFocus.value = true;
-  emit("focusin");
+  emit("focusin", e);
 };
-const onFocusOut = () => {
+const onFocusOut = (e: FocusEvent) => {
   hasFocus.value = true;
-  emit("focusout");
+  emit("focusout", e);
 };
 </script>

--- a/packages/wiz-ui-next/src/components/base/inputs/base/base.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/base/base.vue
@@ -10,8 +10,8 @@
     :placeholder="placeholder"
     :disabled="disabled"
     :type="type"
-    @focusin="hasFocus = true"
-    @focusout="hasFocus = false"
+    @focusin="onFocusIn"
+    @focusout="onFocusOut"
     v-model="textValue"
     :id="id"
     :autocomplete="autocomplete"
@@ -80,6 +80,8 @@ const props = defineProps({
 
 interface Emit {
   (e: "update:modelValue", value: string): void;
+  (e: "focusin"): void;
+  (e: "focusout"): void;
 }
 
 const emit = defineEmits<Emit>();
@@ -98,4 +100,13 @@ const state = computed(() => {
   if (hasFocus.value) return "active";
   return "default";
 });
+
+const onFocusIn = () => {
+  hasFocus.value = true;
+  emit("focusin");
+};
+const onFocusOut = () => {
+  hasFocus.value = true;
+  emit("focusout");
+};
 </script>

--- a/packages/wiz-ui-next/src/components/base/inputs/password/password.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/password/password.vue
@@ -11,8 +11,8 @@
       :type="isPasswordVisible ? 'text' : 'password'"
       :autocomplete="autocomplete"
       space-type="right"
-      @focusin="emit('focusin')"
-      @focusout="emit('focusout')"
+      @focusin="onFocusIn"
+      @focusout="onFocusOut"
     />
     <button
       type="button"
@@ -50,8 +50,8 @@ defineOptions({
 
 interface Emit {
   (e: "update:modelValue", value: string): void;
-  (e: "focusin"): void;
-  (e: "focusout"): void;
+  (e: "focusin", value: FocusEvent): void;
+  (e: "focusout", value: FocusEvent): void;
 }
 
 const props = defineProps({
@@ -102,4 +102,8 @@ const computedExpand = computed(() => (props.expand ? "expand" : "default"));
 // Form Control
 const form = inject(formControlKey);
 const isError = computed(() => (form ? form.isError.value : false));
+
+const onFocusIn = (e: FocusEvent) => emit("focusin", e);
+
+const onFocusOut = (e: FocusEvent) => emit("focusout", e);
 </script>

--- a/packages/wiz-ui-next/src/components/base/inputs/password/password.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/password/password.vue
@@ -11,6 +11,8 @@
       :type="isPasswordVisible ? 'text' : 'password'"
       :autocomplete="autocomplete"
       space-type="right"
+      @focusin="emit('focusin')"
+      @focusout="emit('focusout')"
     />
     <button
       type="button"
@@ -48,6 +50,8 @@ defineOptions({
 
 interface Emit {
   (e: "update:modelValue", value: string): void;
+  (e: "focusin"): void;
+  (e: "focusout"): void;
 }
 
 const props = defineProps({

--- a/packages/wiz-ui-next/src/components/base/inputs/text/text.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/text/text.vue
@@ -12,8 +12,8 @@
       type="text"
       :space-type="icon ? 'left' : 'none'"
       :autocomplete="autocomplete"
-      @focusin="emit('focusin')"
-      @focusout="emit('focusout')"
+      @focusin="onFocusIn"
+      @focusout="onFocusOut"
     />
   </div>
 </template>
@@ -74,8 +74,8 @@ const props = defineProps({
 });
 interface Emit {
   (e: "update:modelValue", value: string): void;
-  (e: "focusin"): void;
-  (e: "focusout"): void;
+  (e: "focusin", value: FocusEvent): void;
+  (e: "focusout", value: FocusEvent): void;
 }
 
 const emit = defineEmits<Emit>();
@@ -90,4 +90,7 @@ const form = inject(formControlKey);
 const isError = computed(() => (form ? form.isError.value : false));
 
 const computedExpand = computed(() => (props.expand ? "expand" : "default"));
+
+const onFocusIn = (e: FocusEvent) => emit("focusin", e);
+const onFocusOut = (e: FocusEvent) => emit("focusout", e);
 </script>

--- a/packages/wiz-ui-next/src/components/base/inputs/text/text.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/text/text.vue
@@ -12,6 +12,8 @@
       type="text"
       :space-type="icon ? 'left' : 'none'"
       :autocomplete="autocomplete"
+      @focusin="emit('focusin')"
+      @focusout="emit('focusout')"
     />
   </div>
 </template>
@@ -72,6 +74,8 @@ const props = defineProps({
 });
 interface Emit {
   (e: "update:modelValue", value: string): void;
+  (e: "focusin"): void;
+  (e: "focusout"): void;
 }
 
 const emit = defineEmits<Emit>();

--- a/packages/wiz-ui-react/src/components/base/inputs/password/components/password-input.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/password/components/password-input.tsx
@@ -5,7 +5,7 @@ import {
 } from "@wizleap-inc/wiz-ui-constants";
 import * as styles from "@wizleap-inc/wiz-ui-styles/bases/password-input.css";
 import clsx from "clsx";
-import { forwardRef, useContext, useState } from "react";
+import { ComponentProps, forwardRef, useContext, useState } from "react";
 
 import { WizIEye } from "@/components";
 import { FormControlContext } from "@/components/custom/form/components/form-control-context";
@@ -13,6 +13,7 @@ import { BaseProps } from "@/types";
 
 import { PrivateBaseInput } from "../../base";
 
+type PrivateBaseInputProps = ComponentProps<typeof PrivateBaseInput>;
 type Props = BaseProps & {
   id?: string;
   value: string;
@@ -23,7 +24,7 @@ type Props = BaseProps & {
   autocomplete?: Extract<AutoCompleteKeys, "currentPassword" | "newPassword">;
   error?: boolean;
   onChange: (value: string) => void;
-};
+} & Omit<PrivateBaseInputProps, "onChange">;
 
 const PasswordInput = forwardRef<HTMLInputElement, Props>(
   (
@@ -39,6 +40,7 @@ const PasswordInput = forwardRef<HTMLInputElement, Props>(
       autocomplete = "off",
       error,
       onChange,
+      ...props
     },
     ref
   ) => {
@@ -69,6 +71,7 @@ const PasswordInput = forwardRef<HTMLInputElement, Props>(
           autoComplete={autocomplete}
           space-type="right"
           onChange={(e) => onChange(e.target.value)}
+          {...props}
         />
         <button
           type="button"


### PR DESCRIPTION
# タスク

resolve: #1184

Input にて、focusin, focusout が継承されない事象の修正を行った。
コンポーネントについて、以下のコンポーネントが対象

- Text Input (Vue のみ)
- Password (Vue, React) 


<!-- reviewerにオーナーを追加してください-->
