### PR TITLE
optionのvalueの型をnumberからTにする 

### DIFF
--- a/.changeset/quiet-clocks-jam.md
+++ b/.changeset/quiet-clocks-jam.md
@@ -1,0 +1,6 @@
+---
+"@wizleap-inc/wiz-ui-react": minor
+"@wizleap-inc/wiz-ui-next": minor
+---
+
+[#1190] Select の Option の型を後で注入できるように修正

--- a/packages/wiz-ui-next/src/components/custom/timeline/stories/timeline-item.stories.ts
+++ b/packages/wiz-ui-next/src/components/custom/timeline/stories/timeline-item.stories.ts
@@ -279,7 +279,7 @@ MobileDevice.args = {
 MobileDevice.decorators = [
   () => ({
     setup() {
-      const device = ref("mobile");
+      const device = ref<"mobile" | "pc">("mobile");
       provide(TIMELINE_KEY, { device });
     },
     template: `<story />`,

--- a/packages/wiz-ui-react/src/components/base/inputs/search-input/components/search-input.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-input/components/search-input.tsx
@@ -10,9 +10,9 @@ import { BaseProps } from "@/types";
 import { SearchPopupPanel } from "./search-popup-panel";
 import { SearchInputOption } from "./types";
 
-type Props = BaseProps & {
-  options: SearchInputOption<number>[];
-  values: number[];
+type Props<T> = BaseProps & {
+  options: SearchInputOption<T>[];
+  values: T[];
   name?: string;
   placeholder?: string;
   disabled?: boolean;
@@ -22,13 +22,13 @@ type Props = BaseProps & {
   isDirectionFixed?: boolean;
   emptyMessage?: string;
   icon?: TIcon;
-  onChangeValues: (values: number[]) => void;
+  onChangeValues: (values: T[]) => void;
 };
 
-function filterOptions(
-  options: SearchInputOption<number>[],
+function filterOptions<T>(
+  options: SearchInputOption<T>[],
   text: string
-): SearchInputOption<number>[] {
+): SearchInputOption<T>[] {
   return options.flatMap((option) => {
     const isMatched = option.label.includes(text);
     if (!option.children || option.children.length === 0) {
@@ -61,7 +61,7 @@ const SearchInput = <T,>({
   emptyMessage = "選択肢がありません。",
   onChangeValues,
   icon = WizISearch,
-}: Props) => {
+}: Props<T>) => {
   const [filteringText, setFilteringText] = useState("");
   const [isFocused, setIsFocused] = useState(false);
   const [isPopupOpen, setIsPopupOpen] = useState(false);
@@ -117,7 +117,7 @@ const SearchInput = <T,>({
               values={values}
               width={popupWidth}
               emptyMessage={emptyMessage}
-              onChangeValues={(changed: number[]) => onChangeValues(changed)}
+              onChangeValues={(changed: T[]) => onChangeValues(changed)}
             />
           </WizHStack>
         </WizPopup>

--- a/packages/wiz-ui-react/src/components/base/inputs/search-input/components/search-input.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-input/components/search-input.tsx
@@ -2,7 +2,7 @@ import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
 import * as styles from "@wizleap-inc/wiz-ui-styles/bases/search-input.css";
 import { inputBorderStyle } from "@wizleap-inc/wiz-ui-styles/commons";
 import clsx from "clsx";
-import { FC, useMemo, useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 
 import { TIcon, WizHStack, WizISearch, WizPopup } from "@/components";
 import { BaseProps } from "@/types";
@@ -10,9 +10,9 @@ import { BaseProps } from "@/types";
 import { SearchPopupPanel } from "./search-popup-panel";
 import { SearchInputOption } from "./types";
 
-type Props<T> = BaseProps & {
-  options: SearchInputOption<T>[];
-  values: T[];
+type Props = BaseProps & {
+  options: SearchInputOption<number>[];
+  values: number[];
   name?: string;
   placeholder?: string;
   disabled?: boolean;
@@ -22,13 +22,13 @@ type Props<T> = BaseProps & {
   isDirectionFixed?: boolean;
   emptyMessage?: string;
   icon?: TIcon;
-  onChangeValues: (values: T[]) => void;
+  onChangeValues: (values: number[]) => void;
 };
 
 function filterOptions(
-  options: SearchInputOption<unknown>[],
+  options: SearchInputOption<number>[],
   text: string
-): SearchInputOption<unknown>[] {
+): SearchInputOption<number>[] {
   return options.flatMap((option) => {
     const isMatched = option.label.includes(text);
     if (!option.children || option.children.length === 0) {
@@ -46,7 +46,7 @@ function filterOptions(
   });
 }
 
-const SearchInput: FC<Props<unknown>> = ({
+const SearchInput = <T,>({
   className,
   style,
   options,
@@ -61,7 +61,7 @@ const SearchInput: FC<Props<unknown>> = ({
   emptyMessage = "選択肢がありません。",
   onChangeValues,
   icon = WizISearch,
-}) => {
+}: Props) => {
   const [filteringText, setFilteringText] = useState("");
   const [isFocused, setIsFocused] = useState(false);
   const [isPopupOpen, setIsPopupOpen] = useState(false);
@@ -117,7 +117,7 @@ const SearchInput: FC<Props<unknown>> = ({
               values={values}
               width={popupWidth}
               emptyMessage={emptyMessage}
-              onChangeValues={(changed: unknown[]) => onChangeValues(changed)}
+              onChangeValues={(changed: number[]) => onChangeValues(changed)}
             />
           </WizHStack>
         </WizPopup>

--- a/packages/wiz-ui-react/src/components/base/inputs/search-input/components/search-input.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-input/components/search-input.tsx
@@ -10,7 +10,7 @@ import { BaseProps } from "@/types";
 import { SearchPopupPanel } from "./search-popup-panel";
 import { SearchInputOption } from "./types";
 
-type Props<T = number> = BaseProps & {
+type Props<T> = BaseProps & {
   options: SearchInputOption<T>[];
   values: T[];
   name?: string;
@@ -22,13 +22,13 @@ type Props<T = number> = BaseProps & {
   isDirectionFixed?: boolean;
   emptyMessage?: string;
   icon?: TIcon;
-  onChangeValues: (values: number[]) => void;
+  onChangeValues: (values: T[]) => void;
 };
 
 function filterOptions(
-  options: SearchInputOption<number>[],
+  options: SearchInputOption<unknown>[],
   text: string
-): SearchInputOption<number>[] {
+): SearchInputOption<unknown>[] {
   return options.flatMap((option) => {
     const isMatched = option.label.includes(text);
     if (!option.children || option.children.length === 0) {
@@ -46,7 +46,7 @@ function filterOptions(
   });
 }
 
-const SearchInput: FC<Props> = ({
+const SearchInput: FC<Props<unknown>> = ({
   className,
   style,
   options,
@@ -117,7 +117,7 @@ const SearchInput: FC<Props> = ({
               values={values}
               width={popupWidth}
               emptyMessage={emptyMessage}
-              onChangeValues={(changed) => onChangeValues(changed)}
+              onChangeValues={(changed: unknown[]) => onChangeValues(changed)}
             />
           </WizHStack>
         </WizPopup>

--- a/packages/wiz-ui-react/src/components/base/inputs/search-input/components/search-input.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-input/components/search-input.tsx
@@ -10,9 +10,9 @@ import { BaseProps } from "@/types";
 import { SearchPopupPanel } from "./search-popup-panel";
 import { SearchInputOption } from "./types";
 
-type Props = BaseProps & {
-  options: SearchInputOption[];
-  values: number[];
+type Props<T = number> = BaseProps & {
+  options: SearchInputOption<T>[];
+  values: T[];
   name?: string;
   placeholder?: string;
   disabled?: boolean;
@@ -26,9 +26,9 @@ type Props = BaseProps & {
 };
 
 function filterOptions(
-  options: SearchInputOption[],
+  options: SearchInputOption<number>[],
   text: string
-): SearchInputOption[] {
+): SearchInputOption<number>[] {
   return options.flatMap((option) => {
     const isMatched = option.label.includes(text);
     if (!option.children || option.children.length === 0) {

--- a/packages/wiz-ui-react/src/components/base/inputs/search-input/components/search-popup-panel.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-input/components/search-popup-panel.tsx
@@ -1,6 +1,6 @@
 import * as styles from "@wizleap-inc/wiz-ui-styles/bases/search-input.css";
 import clsx from "clsx";
-import { FC, useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import {
   WizCheckBoxNew,
@@ -14,15 +14,15 @@ import { BaseProps } from "@/types";
 
 import { SearchInputOption } from "./types";
 
-type Props<T> = BaseProps & {
-  options: SearchInputOption<T>[];
-  values: T[];
+type Props = BaseProps & {
+  options: SearchInputOption<number>[];
+  values: number[];
   width?: string;
   emptyMessage: string;
-  onChangeValues: (values: T[]) => void;
+  onChangeValues: (values: number[]) => void;
 };
 
-export const SearchPopupPanel: FC<Props<unknown>> = ({
+export const SearchPopupPanel = <T,>({
   className,
   style,
   options,
@@ -30,8 +30,9 @@ export const SearchPopupPanel: FC<Props<unknown>> = ({
   width,
   emptyMessage,
   onChangeValues,
-}) => {
-  const [activeValue, setActiveValue] = useState<unknown | null>(null);
+}: Props) => {
+  // TODO: value は number に固定
+  const [activeValue, setActiveValue] = useState<number | null>(null);
   const activeOption = useMemo(
     () => options.find((option) => activeValue === option.value),
     [activeValue, options]
@@ -41,7 +42,7 @@ export const SearchPopupPanel: FC<Props<unknown>> = ({
   const isOpen = activeOptionChildren !== undefined;
 
   const handleChangeValues = useCallback(
-    (selectedOptionValue: string, isChecked: boolean) => {
+    (selectedOptionValue: number, isChecked: boolean) => {
       const newValues = (() => {
         if (isChecked) {
           return [...values, selectedOptionValue];
@@ -127,10 +128,7 @@ export const SearchPopupPanel: FC<Props<unknown>> = ({
                       id={`${option.label}-${option.value}`}
                       checked={values.includes(option.value)}
                       onChange={(e) => {
-                        handleChangeValues(
-                          String(option.value),
-                          e.target.checked
-                        );
+                        handleChangeValues(option.value, e.target.checked);
                       }}
                     >
                       <WizHStack width="100%" align="center" gap="xs2" nowrap>

--- a/packages/wiz-ui-react/src/components/base/inputs/search-input/components/search-popup-panel.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-input/components/search-popup-panel.tsx
@@ -14,8 +14,8 @@ import { BaseProps } from "@/types";
 
 import { SearchInputOption } from "./types";
 
-type Props = BaseProps & {
-  options: SearchInputOption[];
+type Props<T = number> = BaseProps & {
+  options: SearchInputOption<T>[];
   values: number[];
   width?: string;
   emptyMessage: string;

--- a/packages/wiz-ui-react/src/components/base/inputs/search-input/components/search-popup-panel.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-input/components/search-popup-panel.tsx
@@ -14,12 +14,12 @@ import { BaseProps } from "@/types";
 
 import { SearchInputOption } from "./types";
 
-type Props = BaseProps & {
-  options: SearchInputOption<number>[];
-  values: number[];
+type Props<T> = BaseProps & {
+  options: SearchInputOption<T>[];
+  values: T[];
   width?: string;
   emptyMessage: string;
-  onChangeValues: (values: number[]) => void;
+  onChangeValues: (values: T[]) => void;
 };
 
 export const SearchPopupPanel = <T,>({
@@ -30,9 +30,9 @@ export const SearchPopupPanel = <T,>({
   width,
   emptyMessage,
   onChangeValues,
-}: Props) => {
+}: Props<T>) => {
   // TODO: value は number に固定
-  const [activeValue, setActiveValue] = useState<number | null>(null);
+  const [activeValue, setActiveValue] = useState<T | null>(null);
   const activeOption = useMemo(
     () => options.find((option) => activeValue === option.value),
     [activeValue, options]
@@ -42,7 +42,7 @@ export const SearchPopupPanel = <T,>({
   const isOpen = activeOptionChildren !== undefined;
 
   const handleChangeValues = useCallback(
-    (selectedOptionValue: number, isChecked: boolean) => {
+    (selectedOptionValue: T, isChecked: boolean) => {
       const newValues = (() => {
         if (isChecked) {
           return [...values, selectedOptionValue];

--- a/packages/wiz-ui-react/src/components/base/inputs/search-input/components/search-popup-panel.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-input/components/search-popup-panel.tsx
@@ -14,15 +14,15 @@ import { BaseProps } from "@/types";
 
 import { SearchInputOption } from "./types";
 
-type Props<T = number> = BaseProps & {
+type Props<T> = BaseProps & {
   options: SearchInputOption<T>[];
-  values: number[];
+  values: T[];
   width?: string;
   emptyMessage: string;
-  onChangeValues: (values: number[]) => void;
+  onChangeValues: (values: T[]) => void;
 };
 
-export const SearchPopupPanel: FC<Props> = ({
+export const SearchPopupPanel: FC<Props<unknown>> = ({
   className,
   style,
   options,
@@ -31,7 +31,7 @@ export const SearchPopupPanel: FC<Props> = ({
   emptyMessage,
   onChangeValues,
 }) => {
-  const [activeValue, setActiveValue] = useState<number | null>(null);
+  const [activeValue, setActiveValue] = useState<unknown | null>(null);
   const activeOption = useMemo(
     () => options.find((option) => activeValue === option.value),
     [activeValue, options]
@@ -41,7 +41,7 @@ export const SearchPopupPanel: FC<Props> = ({
   const isOpen = activeOptionChildren !== undefined;
 
   const handleChangeValues = useCallback(
-    (selectedOptionValue: number, isChecked: boolean) => {
+    (selectedOptionValue: string, isChecked: boolean) => {
       const newValues = (() => {
         if (isChecked) {
           return [...values, selectedOptionValue];
@@ -123,11 +123,14 @@ export const SearchPopupPanel: FC<Props> = ({
                   <div className={styles.searchDropdownCheckboxItemStyle}>
                     <WizCheckBoxNew
                       style={{ width: "100%" }}
-                      value={option.value}
+                      value={String(option.value)}
                       id={`${option.label}-${option.value}`}
                       checked={values.includes(option.value)}
                       onChange={(e) => {
-                        handleChangeValues(option.value, e.target.checked);
+                        handleChangeValues(
+                          String(option.value),
+                          e.target.checked
+                        );
                       }}
                     >
                       <WizHStack width="100%" align="center" gap="xs2" nowrap>

--- a/packages/wiz-ui-react/src/components/base/inputs/search-input/components/types.ts
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-input/components/types.ts
@@ -2,9 +2,9 @@ export type Tag = {
   label: string;
 };
 
-export type SearchInputOption = {
+export type SearchInputOption<T> = {
   label: string;
-  value: number;
-  children?: SearchInputOption[];
+  value: T;
+  children?: SearchInputOption<T>[];
   tag?: Tag;
 };

--- a/packages/wiz-ui-react/src/components/base/inputs/search-input/stories/dummy-data.ts
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-input/stories/dummy-data.ts
@@ -4,7 +4,7 @@ const tag = {
   label: "タグ",
 };
 
-export const normalOptions: SearchInputOption<unknown>[] = [
+export const normalOptions: SearchInputOption<number>[] = [
   {
     label: "テスト会社1",
     value: 1,
@@ -208,7 +208,7 @@ export const normalOptions: SearchInputOption<unknown>[] = [
   },
 ];
 
-export const longLabelOptions: SearchInputOption<unknown>[] = [
+export const longLabelOptions: SearchInputOption<number>[] = [
   {
     label: "テスト会社1",
     value: 1,
@@ -233,7 +233,7 @@ export const longLabelOptions: SearchInputOption<unknown>[] = [
   },
 ];
 
-export const taggedOptions: SearchInputOption<unknown>[] = [
+export const taggedOptions: SearchInputOption<number>[] = [
   {
     label: "テスト会社1",
     value: 1,
@@ -328,8 +328,8 @@ const getNextValue = (): number => {
 const generateGrandchildren = (
   startValue: number,
   count: number
-): SearchInputOption<unknown>[] => {
-  const grandchildren: SearchInputOption<unknown>[] = [];
+): SearchInputOption<number>[] => {
+  const grandchildren: SearchInputOption<number>[] = [];
   for (let i = 0; i < count; i++) {
     const grandchildValue = getNextValue();
     grandchildren.push({
@@ -344,8 +344,8 @@ const generateGrandchildren = (
 const generateChildren = (
   startValue: number,
   count: number
-): SearchInputOption<unknown>[] => {
-  const children: SearchInputOption<unknown>[] = [];
+): SearchInputOption<number>[] => {
+  const children: SearchInputOption<number>[] = [];
   for (let i = 0; i < count; i++) {
     const childValue = getNextValue();
     children.push({
@@ -365,8 +365,8 @@ const generateChildren = (
 const generateParentElements = (
   startValue: number,
   count: number
-): SearchInputOption<unknown>[] => {
-  const parentElements: SearchInputOption<unknown>[] = [];
+): SearchInputOption<number>[] => {
+  const parentElements: SearchInputOption<number>[] = [];
   for (let i = 0; i < count; i++) {
     const parentValue = getNextValue();
     parentElements.push({
@@ -378,7 +378,7 @@ const generateParentElements = (
   return parentElements;
 };
 
-export const debugOptions: SearchInputOption<unknown>[] = [
+export const debugOptions: SearchInputOption<number>[] = [
   {
     label: "親要素1",
     value: getNextValue(),
@@ -397,7 +397,7 @@ export const debugOptions: SearchInputOption<unknown>[] = [
   ...generateParentElements(getNextValue(), 13),
 ];
 
-export const emptyMessageOptions: SearchInputOption<unknown>[] = [
+export const emptyMessageOptions: SearchInputOption<number>[] = [
   {
     label: "テスト会社1",
     value: 1,

--- a/packages/wiz-ui-react/src/components/base/inputs/search-input/stories/dummy-data.ts
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-input/stories/dummy-data.ts
@@ -4,7 +4,7 @@ const tag = {
   label: "タグ",
 };
 
-export const normalOptions: SearchInputOption[] = [
+export const normalOptions: SearchInputOption<unknown>[] = [
   {
     label: "テスト会社1",
     value: 1,
@@ -208,7 +208,7 @@ export const normalOptions: SearchInputOption[] = [
   },
 ];
 
-export const longLabelOptions: SearchInputOption[] = [
+export const longLabelOptions: SearchInputOption<unknown>[] = [
   {
     label: "テスト会社1",
     value: 1,
@@ -233,7 +233,7 @@ export const longLabelOptions: SearchInputOption[] = [
   },
 ];
 
-export const taggedOptions: SearchInputOption[] = [
+export const taggedOptions: SearchInputOption<unknown>[] = [
   {
     label: "テスト会社1",
     value: 1,
@@ -328,8 +328,8 @@ const getNextValue = (): number => {
 const generateGrandchildren = (
   startValue: number,
   count: number
-): SearchInputOption[] => {
-  const grandchildren: SearchInputOption[] = [];
+): SearchInputOption<unknown>[] => {
+  const grandchildren: SearchInputOption<unknown>[] = [];
   for (let i = 0; i < count; i++) {
     const grandchildValue = getNextValue();
     grandchildren.push({
@@ -344,8 +344,8 @@ const generateGrandchildren = (
 const generateChildren = (
   startValue: number,
   count: number
-): SearchInputOption[] => {
-  const children: SearchInputOption[] = [];
+): SearchInputOption<unknown>[] => {
+  const children: SearchInputOption<unknown>[] = [];
   for (let i = 0; i < count; i++) {
     const childValue = getNextValue();
     children.push({
@@ -365,8 +365,8 @@ const generateChildren = (
 const generateParentElements = (
   startValue: number,
   count: number
-): SearchInputOption[] => {
-  const parentElements: SearchInputOption[] = [];
+): SearchInputOption<unknown>[] => {
+  const parentElements: SearchInputOption<unknown>[] = [];
   for (let i = 0; i < count; i++) {
     const parentValue = getNextValue();
     parentElements.push({
@@ -378,7 +378,7 @@ const generateParentElements = (
   return parentElements;
 };
 
-export const debugOptions: SearchInputOption[] = [
+export const debugOptions: SearchInputOption<unknown>[] = [
   {
     label: "親要素1",
     value: getNextValue(),
@@ -397,7 +397,7 @@ export const debugOptions: SearchInputOption[] = [
   ...generateParentElements(getNextValue(), 13),
 ];
 
-export const emptyMessageOptions: SearchInputOption[] = [
+export const emptyMessageOptions: SearchInputOption<unknown>[] = [
   {
     label: "テスト会社1",
     value: 1,

--- a/packages/wiz-ui-react/src/components/base/inputs/search-input/stories/search-input.stories.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-input/stories/search-input.stories.tsx
@@ -25,7 +25,7 @@ type Story = StoryObj<typeof WizSearchInput>;
 
 const Template: Story = {
   render: (args) => {
-    const [values, setValues] = useState<number[]>([]);
+    const [values, setValues] = useState<unknown[]>([]);
     return (
       <div>
         values:[{values.join(", ")}]

--- a/packages/wiz-ui-react/src/components/base/inputs/search-input/stories/search-input.stories.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-input/stories/search-input.stories.tsx
@@ -21,7 +21,7 @@ const meta: Meta<typeof WizSearchInput> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof WizSearchInput>;
+type Story = StoryObj<typeof WizSearchInput<number>>;
 
 const Template: Story = {
   render: (args) => {

--- a/packages/wiz-ui-react/src/components/base/inputs/search-input/stories/search-input.stories.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-input/stories/search-input.stories.tsx
@@ -25,7 +25,7 @@ type Story = StoryObj<typeof WizSearchInput>;
 
 const Template: Story = {
   render: (args) => {
-    const [values, setValues] = useState<unknown[]>([]);
+    const [values, setValues] = useState<number[]>([]);
     return (
       <div>
         values:[{values.join(", ")}]

--- a/packages/wiz-ui-react/src/components/base/inputs/search-selector/components/search-selector-helper.ts
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-selector/components/search-selector-helper.ts
@@ -19,8 +19,8 @@ function levenshteinDistance(s1: string, s2: string): number {
   return dist[s1.length][s2.length] / Math.max(s1.length, s2.length);
 }
 
-export function filterOptions(
-  options: SearchSelectorOption<unknown>[],
+export function filterOptions<T>(
+  options: SearchSelectorOption<T>[],
   searchText: string
 ) {
   if (searchText.length === 0) {

--- a/packages/wiz-ui-react/src/components/base/inputs/search-selector/components/search-selector-helper.ts
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-selector/components/search-selector-helper.ts
@@ -20,7 +20,7 @@ function levenshteinDistance(s1: string, s2: string): number {
 }
 
 export function filterOptions(
-  options: SearchSelectorOption[],
+  options: SearchSelectorOption<unknown>[],
   searchText: string
 ) {
   if (searchText.length === 0) {

--- a/packages/wiz-ui-react/src/components/base/inputs/search-selector/components/search-selector.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-selector/components/search-selector.tsx
@@ -31,9 +31,9 @@ import { BaseProps } from "@/types";
 import { filterOptions } from "./search-selector-helper";
 import { SearchSelectorOption } from "./types";
 
-type Props = BaseProps & {
-  options: SearchSelectorOption[];
-  values: number[];
+type Props<T = number> = BaseProps & {
+  options: SearchSelectorOption<T>[];
+  values: T[];
   placeholder?: string;
   width?: string;
   disabled?: boolean;

--- a/packages/wiz-ui-react/src/components/base/inputs/search-selector/components/search-selector.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-selector/components/search-selector.tsx
@@ -31,7 +31,7 @@ import { BaseProps } from "@/types";
 import { filterOptions } from "./search-selector-helper";
 import { SearchSelectorOption } from "./types";
 
-type Props<T = number> = BaseProps & {
+type Props<T> = BaseProps & {
   options: SearchSelectorOption<T>[];
   values: T[];
   placeholder?: string;
@@ -44,12 +44,12 @@ type Props<T = number> = BaseProps & {
   isDirectionFixed?: boolean;
   showExLabel?: boolean;
   dropdownMaxHeight?: string;
-  onChangeValues: (values: number[]) => void;
+  onChangeValues: (values: T[]) => void;
   onCreate?: (label: string) => void;
   onInputSearchText?: (text: string) => void;
 };
 
-const SearchSelector: FC<Props> = ({
+const SearchSelector: FC<Props<unknown>> = ({
   className,
   style,
   options,
@@ -92,13 +92,13 @@ const SearchSelector: FC<Props> = ({
     );
   }, [selectedOptions.length]);
 
-  const buttonGroupOptions: ButtonGroupItem[] = useMemo(() => {
+  const buttonGroupOptions: ButtonGroupItem<unknown>[] = useMemo(() => {
     const filteredOptions = filterOptions(options, searchText).filter(
       (matchedOption) => {
         return !values.some((value) => matchedOption.value === value);
       }
     );
-    const buttonGroupOptions: ButtonGroupItem[] = filteredOptions.map(
+    const buttonGroupOptions: ButtonGroupItem<unknown>[] = filteredOptions.map(
       (option) => {
         return {
           kind: "button",
@@ -149,7 +149,7 @@ const SearchSelector: FC<Props> = ({
     values,
   ]);
 
-  const unselectOption = (option: SearchSelectorOption) => {
+  const unselectOption = (option: SearchSelectorOption<unknown>) => {
     onChangeValues(values.filter((value) => value !== option.value));
     setTimeout(() => {
       // input 要素が描画されるのを待ってフォーカス
@@ -158,7 +158,7 @@ const SearchSelector: FC<Props> = ({
   };
 
   const handleClickClearButton = (
-    option: SearchSelectorOption
+    option: SearchSelectorOption<unknown>
   ): MouseEventHandler => {
     return (e) => {
       e.stopPropagation();
@@ -180,7 +180,9 @@ const SearchSelector: FC<Props> = ({
   };
 
   const keyDownHandlers = {
-    clearButton: (option: SearchSelectorOption): KeyboardEventHandler => {
+    clearButton: (
+      option: SearchSelectorOption<unknown>
+    ): KeyboardEventHandler => {
       return (e) => {
         if (e.key === "Backspace") {
           unselectOption(option);

--- a/packages/wiz-ui-react/src/components/base/inputs/search-selector/components/search-selector.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-selector/components/search-selector.tsx
@@ -3,7 +3,6 @@ import * as styles from "@wizleap-inc/wiz-ui-styles/bases/search-selector.css";
 import { inputBorderStyle } from "@wizleap-inc/wiz-ui-styles/commons";
 import clsx from "clsx";
 import {
-  FC,
   KeyboardEvent,
   KeyboardEventHandler,
   MouseEventHandler,
@@ -31,9 +30,10 @@ import { BaseProps } from "@/types";
 import { filterOptions } from "./search-selector-helper";
 import { SearchSelectorOption } from "./types";
 
-type Props<T> = BaseProps & {
-  options: SearchSelectorOption<T>[];
-  values: T[];
+// TODO: Search Selector は number で固定
+type Props = BaseProps & {
+  options: SearchSelectorOption<number>[];
+  values: number[];
   placeholder?: string;
   width?: string;
   disabled?: boolean;
@@ -44,12 +44,12 @@ type Props<T> = BaseProps & {
   isDirectionFixed?: boolean;
   showExLabel?: boolean;
   dropdownMaxHeight?: string;
-  onChangeValues: (values: T[]) => void;
+  onChangeValues: (values: number[]) => void;
   onCreate?: (label: string) => void;
   onInputSearchText?: (text: string) => void;
 };
 
-const SearchSelector: FC<Props<unknown>> = ({
+const SearchSelector = ({
   className,
   style,
   options,
@@ -67,7 +67,7 @@ const SearchSelector: FC<Props<unknown>> = ({
   onChangeValues,
   onCreate,
   onInputSearchText,
-}) => {
+}: Props) => {
   const [searchText, setSearchText] = useState("");
   const [isPopupOpen, setIsPopupOpen] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
@@ -92,13 +92,13 @@ const SearchSelector: FC<Props<unknown>> = ({
     );
   }, [selectedOptions.length]);
 
-  const buttonGroupOptions: ButtonGroupItem<unknown>[] = useMemo(() => {
+  const buttonGroupOptions: ButtonGroupItem<number>[] = useMemo(() => {
     const filteredOptions = filterOptions(options, searchText).filter(
       (matchedOption) => {
         return !values.some((value) => matchedOption.value === value);
       }
     );
-    const buttonGroupOptions: ButtonGroupItem<unknown>[] = filteredOptions.map(
+    const buttonGroupOptions: ButtonGroupItem<number>[] = filteredOptions.map(
       (option) => {
         return {
           kind: "button",
@@ -124,6 +124,8 @@ const SearchSelector: FC<Props<unknown>> = ({
       addable &&
       searchText !== "" &&
       options.every((option) => option.label !== searchText);
+
+    // MEMO： この value が -1 であるため number で固定
     return shouldShowAddButton
       ? [
           {
@@ -149,7 +151,7 @@ const SearchSelector: FC<Props<unknown>> = ({
     values,
   ]);
 
-  const unselectOption = (option: SearchSelectorOption<unknown>) => {
+  const unselectOption = (option: SearchSelectorOption<number>) => {
     onChangeValues(values.filter((value) => value !== option.value));
     setTimeout(() => {
       // input 要素が描画されるのを待ってフォーカス
@@ -158,7 +160,7 @@ const SearchSelector: FC<Props<unknown>> = ({
   };
 
   const handleClickClearButton = (
-    option: SearchSelectorOption<unknown>
+    option: SearchSelectorOption<number>
   ): MouseEventHandler => {
     return (e) => {
       e.stopPropagation();
@@ -181,7 +183,7 @@ const SearchSelector: FC<Props<unknown>> = ({
 
   const keyDownHandlers = {
     clearButton: (
-      option: SearchSelectorOption<unknown>
+      option: SearchSelectorOption<number>
     ): KeyboardEventHandler => {
       return (e) => {
         if (e.key === "Backspace") {

--- a/packages/wiz-ui-react/src/components/base/inputs/search-selector/components/search-selector.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-selector/components/search-selector.tsx
@@ -31,9 +31,9 @@ import { filterOptions } from "./search-selector-helper";
 import { SearchSelectorOption } from "./types";
 
 // TODO: Search Selector は number で固定
-type Props = BaseProps & {
-  options: SearchSelectorOption<number>[];
-  values: number[];
+type Props<T> = BaseProps & {
+  options: SearchSelectorOption<T>[];
+  values: T[];
   placeholder?: string;
   width?: string;
   disabled?: boolean;
@@ -44,11 +44,12 @@ type Props = BaseProps & {
   isDirectionFixed?: boolean;
   showExLabel?: boolean;
   dropdownMaxHeight?: string;
-  onChangeValues: (values: number[]) => void;
+  onChangeValues: (values: T[]) => void;
   onCreate?: (label: string) => void;
   onInputSearchText?: (text: string) => void;
 };
 
+// FIXME: value の default 値を -1 で固定されているため、number 型に固定
 const SearchSelector = ({
   className,
   style,
@@ -67,7 +68,7 @@ const SearchSelector = ({
   onChangeValues,
   onCreate,
   onInputSearchText,
-}: Props) => {
+}: Props<number>) => {
   const [searchText, setSearchText] = useState("");
   const [isPopupOpen, setIsPopupOpen] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
@@ -93,7 +94,7 @@ const SearchSelector = ({
   }, [selectedOptions.length]);
 
   const buttonGroupOptions: ButtonGroupItem<number>[] = useMemo(() => {
-    const filteredOptions = filterOptions(options, searchText).filter(
+    const filteredOptions = filterOptions<number>(options, searchText).filter(
       (matchedOption) => {
         return !values.some((value) => matchedOption.value === value);
       }
@@ -125,7 +126,7 @@ const SearchSelector = ({
       searchText !== "" &&
       options.every((option) => option.label !== searchText);
 
-    // MEMO： この value が -1 であるため number で固定
+    // FIXME: value の default 値が -1 なので number 型に固定
     return shouldShowAddButton
       ? [
           {

--- a/packages/wiz-ui-react/src/components/base/inputs/search-selector/components/types.ts
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-selector/components/types.ts
@@ -1,5 +1,5 @@
-export type SearchSelectorOption = {
+export type SearchSelectorOption<T = number> = {
   label: string;
-  value: number;
+  value: T;
   exLabel?: string;
 };

--- a/packages/wiz-ui-react/src/components/base/inputs/search-selector/components/types.ts
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-selector/components/types.ts
@@ -1,4 +1,4 @@
-export type SearchSelectorOption<T = number> = {
+export type SearchSelectorOption<T> = {
   label: string;
   value: T;
   exLabel?: string;

--- a/packages/wiz-ui-react/src/components/base/inputs/search-selector/stories/search-selector.stories.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-selector/stories/search-selector.stories.tsx
@@ -37,7 +37,7 @@ export default meta;
 type Story = StoryObj<typeof WizSearchSelector>;
 
 const getDummyOptions = (label: string, count: number, exLabel?: string) => {
-  const options: SearchSelectorOption<unknown>[] = [];
+  const options: SearchSelectorOption<number>[] = [];
   for (let i = 1; i <= count; i++) {
     options.push({ label: label + i, value: i, exLabel });
     options.push({ label: label + i * 10, value: i * 10, exLabel });
@@ -45,10 +45,10 @@ const getDummyOptions = (label: string, count: number, exLabel?: string) => {
   return options;
 };
 
-const getTemplate = (initialValues: unknown[] = []): Story => {
+const getTemplate = (initialValues: number[] = []): Story => {
   return {
     render: (args) => {
-      const [values, setValues] = useState<unknown[]>(initialValues);
+      const [values, setValues] = useState<number[]>(initialValues);
       return (
         <WizSearchSelector
           {...args}

--- a/packages/wiz-ui-react/src/components/base/inputs/search-selector/stories/search-selector.stories.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-selector/stories/search-selector.stories.tsx
@@ -37,7 +37,7 @@ export default meta;
 type Story = StoryObj<typeof WizSearchSelector>;
 
 const getDummyOptions = (label: string, count: number, exLabel?: string) => {
-  const options: SearchSelectorOption[] = [];
+  const options: SearchSelectorOption<unknown>[] = [];
   for (let i = 1; i <= count; i++) {
     options.push({ label: label + i, value: i, exLabel });
     options.push({ label: label + i * 10, value: i * 10, exLabel });
@@ -45,10 +45,10 @@ const getDummyOptions = (label: string, count: number, exLabel?: string) => {
   return options;
 };
 
-const getTemplate = (initialValues: number[] = []): Story => {
+const getTemplate = (initialValues: unknown[] = []): Story => {
   return {
     render: (args) => {
-      const [values, setValues] = useState<number[]>(initialValues);
+      const [values, setValues] = useState<unknown[]>(initialValues);
       return (
         <WizSearchSelector
           {...args}

--- a/packages/wiz-ui-react/src/components/base/inputs/selectbox/components/selectbox.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/selectbox/components/selectbox.tsx
@@ -3,7 +3,6 @@ import * as styles from "@wizleap-inc/wiz-ui-styles/bases/selectbox-input.css";
 import { inputBorderStyle } from "@wizleap-inc/wiz-ui-styles/commons";
 import clsx from "clsx";
 import {
-  FC,
   KeyboardEventHandler,
   useCallback,
   useContext,
@@ -22,6 +21,7 @@ import {
 } from "@/components";
 import { FormControlContext } from "@/components/custom/form/components/form-control-context";
 import { BaseProps } from "@/types";
+
 type SelectBoxOption<T> = {
   label: string;
   exLabel?: string;
@@ -42,7 +42,7 @@ type Props<T> = BaseProps & {
   onChange: (value: T) => void;
 };
 
-const SelectBox: FC<Props<unknown>> = ({
+const SelectBox = <T,>({
   className,
   style,
   options,
@@ -56,7 +56,7 @@ const SelectBox: FC<Props<unknown>> = ({
   showExLabel = false,
   dropdownMaxHeight,
   onChange,
-}) => {
+}: Props<T>) => {
   const [isOpen, setIsOpen] = useState(false);
   const anchorRef = useRef<HTMLDivElement>(null);
   const formControl = useContext(FormControlContext);
@@ -79,7 +79,7 @@ const SelectBox: FC<Props<unknown>> = ({
     setIsOpen(!isOpen);
   };
 
-  const handleClickOption = (option: SelectBoxOption<unknown>) => {
+  const handleClickOption = (option: SelectBoxOption<T>) => {
     setIsOpen(false);
     onChange(option.value);
   };

--- a/packages/wiz-ui-react/src/components/base/inputs/selectbox/components/selectbox.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/selectbox/components/selectbox.tsx
@@ -28,7 +28,7 @@ type SelectBoxOption<T> = {
   value: T;
 };
 
-type Props<T = number | null> = BaseProps & {
+type Props<T> = BaseProps & {
   options: SelectBoxOption<T>[];
   value: T;
   placeholder?: string;
@@ -39,10 +39,10 @@ type Props<T = number | null> = BaseProps & {
   isDirectionFixed?: boolean;
   showExLabel?: boolean;
   dropdownMaxHeight?: string;
-  onChange: (value: unknown) => void;
+  onChange: (value: T) => void;
 };
 
-const SelectBox: FC<Props> = ({
+const SelectBox: FC<Props<unknown>> = ({
   className,
   style,
   options,
@@ -79,7 +79,7 @@ const SelectBox: FC<Props> = ({
     setIsOpen(!isOpen);
   };
 
-  const handleClickOption = (option: SelectBoxOption) => {
+  const handleClickOption = (option: SelectBoxOption<unknown>) => {
     setIsOpen(false);
     onChange(option.value);
   };

--- a/packages/wiz-ui-react/src/components/base/inputs/selectbox/components/selectbox.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/selectbox/components/selectbox.tsx
@@ -22,15 +22,15 @@ import {
 } from "@/components";
 import { FormControlContext } from "@/components/custom/form/components/form-control-context";
 import { BaseProps } from "@/types";
-type SelectBoxOption = {
+type SelectBoxOption<T> = {
   label: string;
   exLabel?: string;
-  value: number;
+  value: T;
 };
 
-type Props = BaseProps & {
-  options: SelectBoxOption[];
-  value: number | null;
+type Props<T = number | null> = BaseProps & {
+  options: SelectBoxOption<T>[];
+  value: T;
   placeholder?: string;
   width?: string;
   disabled?: boolean;
@@ -39,7 +39,7 @@ type Props = BaseProps & {
   isDirectionFixed?: boolean;
   showExLabel?: boolean;
   dropdownMaxHeight?: string;
-  onChange: (value: number | null) => void;
+  onChange: (value: unknown) => void;
 };
 
 const SelectBox: FC<Props> = ({

--- a/packages/wiz-ui-react/src/components/base/inputs/selectbox/stories/selectbox.stories.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/selectbox/stories/selectbox.stories.tsx
@@ -23,12 +23,12 @@ const getDummyOptions = (label: string, length: number, exLabel?: string) => {
 
 const Template: Story = {
   render: (args) => {
-    const [value, setValue] = useState<number | null>(null);
+    const [value, setValue] = useState<unknown | null>();
     return (
       <WizSelectBox
         {...args}
         value={value}
-        onChange={(updated) => setValue(updated)}
+        onChange={(updated: unknown) => setValue(updated)}
       />
     );
   },
@@ -81,7 +81,7 @@ export const ExtraLabel: Story = {
     value: 1,
   },
   render: (args) => {
-    const [value, setValue] = useState<number | null>(args.value);
+    const [value, setValue] = useState<unknown | null>(args.value);
     return (
       <div
         style={{

--- a/packages/wiz-ui-react/src/components/base/navigation/components/navigation-item.tsx
+++ b/packages/wiz-ui-react/src/components/base/navigation/components/navigation-item.tsx
@@ -18,14 +18,14 @@ import { BaseProps } from "@/types";
 
 import { ButtonGroupItem } from "../../popup-button-group/types";
 
-type Props<T extends ElementType> = BaseProps & {
+type Props<T extends ElementType, K> = BaseProps & {
   icon: TIcon;
   label: string;
   active: boolean;
   disabled?: boolean;
   tooltipText?: string;
   isPopupLocking?: boolean;
-  buttons?: ButtonGroupItem[];
+  buttons?: ButtonGroupItem<K>[];
   isPopupOpen?: boolean;
   onTogglePopup?: (isPopup: boolean) => void;
   onTogglePopupLocking?: (lock: boolean) => void;
@@ -54,7 +54,7 @@ type Props<T extends ElementType> = BaseProps & {
  * <WizNavigationItem as={Link} asProps={{ to: "/page1" }} { ...otherProps } />
  * ```
  */
-const NavigationItem = <T extends ElementType>({
+const NavigationItem = <T extends ElementType, K>({
   className,
   style,
   icon: Icon,
@@ -68,7 +68,7 @@ const NavigationItem = <T extends ElementType>({
   onTogglePopup,
   onTogglePopupLocking,
   ...props
-}: Props<T>) => {
+}: Props<T, K>) => {
   const isAnchor = "href" in props;
   const LinkComponent = isAnchor ? "a" : props.as;
   const isExternalLink = !!props?.href?.startsWith("http");

--- a/packages/wiz-ui-react/src/components/base/navigation/stories/navigation-container.stories.tsx
+++ b/packages/wiz-ui-react/src/components/base/navigation/stories/navigation-container.stories.tsx
@@ -147,7 +147,7 @@ export const Fixed: Story = {
   },
 };
 
-const createButton = (n: number): ButtonGroupItem => ({
+const createButton = (n: number): ButtonGroupItem<number> => ({
   kind: "button",
   option: {
     label: `label ${n}`,

--- a/packages/wiz-ui-react/src/components/base/popup-button-group/components/button-item.tsx
+++ b/packages/wiz-ui-react/src/components/base/popup-button-group/components/button-item.tsx
@@ -14,7 +14,7 @@ import { BaseProps } from "@/types";
 import { ButtonItem as ButtonItemType } from "../types";
 
 type Props = BaseProps & {
-  item: ButtonItemType;
+  item: ButtonItemType<unknown>;
   disabled: boolean;
   depth: number;
 };

--- a/packages/wiz-ui-react/src/components/base/popup-button-group/components/button-item.tsx
+++ b/packages/wiz-ui-react/src/components/base/popup-button-group/components/button-item.tsx
@@ -6,26 +6,26 @@ import {
   popupButtonGroupInnerContainerStyle,
 } from "@wizleap-inc/wiz-ui-styles/bases/popup-button-group.css";
 import clsx from "clsx";
-import { FC, KeyboardEvent, useMemo, useState } from "react";
+import { KeyboardEvent, useMemo, useState } from "react";
 
 import { WizIcon } from "@/components";
 import { BaseProps } from "@/types";
 
 import { ButtonItem as ButtonItemType } from "../types";
 
-type Props = BaseProps & {
-  item: ButtonItemType<unknown>;
+type Props<T> = BaseProps & {
+  item: ButtonItemType<T>;
   disabled: boolean;
   depth: number;
 };
 
-export const ButtonItem: FC<Props> = ({
+export const ButtonItem = <T,>({
   className,
   style,
   item,
   disabled,
   depth,
-}) => {
+}: Props<T>) => {
   const [isClicking, setIsClicking] = useState(false);
   const [isHover, setIsHover] = useState(false);
 

--- a/packages/wiz-ui-react/src/components/base/popup-button-group/components/group-item.tsx
+++ b/packages/wiz-ui-react/src/components/base/popup-button-group/components/group-item.tsx
@@ -13,7 +13,7 @@ import { GroupItem as GroupItemType } from "../types";
 import { WizPopupButtonGroup } from "./popup-button-group";
 
 type Props = BaseProps & {
-  item: GroupItemType;
+  item: GroupItemType<unknown>;
   disabled: boolean;
   depth: number;
 };

--- a/packages/wiz-ui-react/src/components/base/popup-button-group/components/group-item.tsx
+++ b/packages/wiz-ui-react/src/components/base/popup-button-group/components/group-item.tsx
@@ -4,7 +4,6 @@ import {
   popupButtonGroupTitleVariantStyle,
 } from "@wizleap-inc/wiz-ui-styles/bases/popup-button-group.css";
 import clsx from "clsx";
-import { FC } from "react";
 
 import { BaseProps } from "@/types";
 
@@ -12,19 +11,19 @@ import { GroupItem as GroupItemType } from "../types";
 
 import { WizPopupButtonGroup } from "./popup-button-group";
 
-type Props = BaseProps & {
-  item: GroupItemType<unknown>;
+type Props<T> = BaseProps & {
+  item: GroupItemType<T>;
   disabled: boolean;
   depth: number;
 };
 
-export const GroupItem: FC<Props> = ({
+export const GroupItem = <T,>({
   className,
   style,
   item,
   disabled,
   depth,
-}) => {
+}: Props<T>) => {
   return (
     <div className={className} style={style}>
       <span

--- a/packages/wiz-ui-react/src/components/base/popup-button-group/components/popup-button-group.tsx
+++ b/packages/wiz-ui-react/src/components/base/popup-button-group/components/popup-button-group.tsx
@@ -16,8 +16,8 @@ import { ButtonItem } from "./button-item";
 import { DividerItem } from "./divider-item";
 import { GroupItem } from "./group-item";
 
-type Props = BaseProps & {
-  options: ButtonGroupItem[];
+type Props<T> = BaseProps & {
+  options: ButtonGroupItem<T>[];
   width?: string;
   p?: SpacingKeys;
   borderRadius?: SpacingKeys;
@@ -28,7 +28,7 @@ type Props = BaseProps & {
   depth?: number;
 };
 
-const PopupButtonGroup: FC<Props> = ({
+const PopupButtonGroup: FC<Props<unknown>> = ({
   className,
   style,
   options,
@@ -42,13 +42,13 @@ const PopupButtonGroup: FC<Props> = ({
   depth = 0,
 }) => {
   const items = useMemo(() => {
-    const divider: ItemElement = { kind: "divider" };
+    const divider: ItemElement<unknown> = { kind: "divider" };
     const items = options
       .map((opt, i) => {
         if (opt.kind === "divider") {
           return [divider];
         }
-        const optionItem: ItemElement = {
+        const optionItem: ItemElement<unknown> = {
           kind: "item",
           item: opt,
         };

--- a/packages/wiz-ui-react/src/components/base/popup-button-group/components/popup-button-group.tsx
+++ b/packages/wiz-ui-react/src/components/base/popup-button-group/components/popup-button-group.tsx
@@ -5,7 +5,7 @@ import {
   popupButtonGroupStyle,
 } from "@wizleap-inc/wiz-ui-styles/bases/popup-button-group.css";
 import clsx from "clsx";
-import { FC, useMemo } from "react";
+import { useMemo } from "react";
 
 import { WizVStack } from "@/components";
 import { BaseProps } from "@/types";
@@ -28,7 +28,7 @@ type Props<T> = BaseProps & {
   depth?: number;
 };
 
-const PopupButtonGroup: FC<Props<unknown>> = ({
+const PopupButtonGroup = <T,>({
   className,
   style,
   options,
@@ -40,15 +40,15 @@ const PopupButtonGroup: FC<Props<unknown>> = ({
   groupDivider = false,
   buttonDivider = false,
   depth = 0,
-}) => {
+}: Props<T>) => {
   const items = useMemo(() => {
-    const divider: ItemElement<unknown> = { kind: "divider" };
+    const divider: ItemElement<T> = { kind: "divider" };
     const items = options
       .map((opt, i) => {
         if (opt.kind === "divider") {
           return [divider];
         }
-        const optionItem: ItemElement<unknown> = {
+        const optionItem: ItemElement<T> = {
           kind: "item",
           item: opt,
         };

--- a/packages/wiz-ui-react/src/components/base/popup-button-group/stories/popup-button-group.stories.tsx
+++ b/packages/wiz-ui-react/src/components/base/popup-button-group/stories/popup-button-group.stories.tsx
@@ -18,7 +18,7 @@ export default meta;
 type Story = StoryObj<typeof WizPopupButtonGroup>;
 
 const getDummyOptions = (count: number) => {
-  const options: PopupButtonOption[] = [];
+  const options: PopupButtonOption<number>[] = [];
   const createIcon = (i: number) => {
     if (i % 3 === 0) {
       return undefined;
@@ -43,7 +43,7 @@ const getDummyOptions = (count: number) => {
     });
   });
   return options.map(
-    (opt) => ({ kind: "button", option: opt } as ButtonGroupItem)
+    (opt) => ({ kind: "button", option: opt } as ButtonGroupItem<number>)
   );
 };
 
@@ -51,7 +51,7 @@ const createButton = (
   n: number,
   disabled?: boolean,
   icon?: TIcon
-): ButtonGroupItem => ({
+): ButtonGroupItem<number> => ({
   kind: "button",
   option: {
     label: `item ${n}`,
@@ -63,7 +63,7 @@ const createButton = (
   },
 });
 
-const dummyItems: ButtonGroupItem[] = [
+const dummyItems: ButtonGroupItem<number>[] = [
   {
     kind: "group",
     title: "タイトル1",

--- a/packages/wiz-ui-react/src/components/base/popup-button-group/types.ts
+++ b/packages/wiz-ui-react/src/components/base/popup-button-group/types.ts
@@ -1,8 +1,8 @@
 import { TIcon } from "@/components";
 
-export interface PopupButtonOption {
+export interface PopupButtonOption<T> {
   label: string;
-  value: number;
+  value: T;
   exLabel?: string;
   icon?: TIcon;
   iconDefaultColor?: "green.800" | "gray.500";
@@ -10,27 +10,27 @@ export interface PopupButtonOption {
   onClick: () => void;
 }
 
-export interface ButtonItem {
+export interface ButtonItem<T> {
   kind: "button";
-  option: PopupButtonOption;
+  option: PopupButtonOption<T>;
 }
 
 interface DividerItem {
   kind: "divider";
 }
 
-export interface GroupItem {
+export interface GroupItem<T> {
   kind: "group";
   title: string;
   // 再帰参照を許可するためにno-use-before-define無効化
   // eslint-disable-next-line no-use-before-define
-  items: ButtonGroupItem[];
+  items: ButtonGroupItem<T>[];
   groupDivider?: boolean;
   buttonDivider?: boolean;
 }
 
-export type ButtonGroupItem = ButtonItem | DividerItem | GroupItem;
+export type ButtonGroupItem<T> = ButtonItem<T> | DividerItem | GroupItem<T>;
 
-export type ItemElement =
+export type ItemElement<T> =
   | DividerItem
-  | { kind: "item"; item: Exclude<ButtonGroupItem, DividerItem> };
+  | { kind: "item"; item: Exclude<ButtonGroupItem<T>, DividerItem> };

--- a/packages/wiz-ui-react/src/components/custom/chat/components/chat-card.tsx
+++ b/packages/wiz-ui-react/src/components/custom/chat/components/chat-card.tsx
@@ -3,7 +3,6 @@ import * as styles from "@wizleap-inc/wiz-ui-styles/customs/chat-card.css";
 import { formatDateToMonthDayWeek } from "@wizleap-inc/wiz-ui-utils";
 import {
   ComponentProps,
-  FC,
   Fragment,
   useCallback,
   useEffect,
@@ -34,7 +33,7 @@ import { WizChatForm, WizChatItem } from ".";
 
 const TOGGLE_ANIMATION_DURATION = 300;
 
-type Props = BaseProps & {
+type Props<T> = BaseProps & {
   textValue: string;
   username: string;
   isOpen: boolean;
@@ -43,16 +42,16 @@ type Props = BaseProps & {
   haveNewMessage?: boolean;
   formRows?: number;
   typingUsername?: string;
-  status?: unknown;
+  status?: T;
   statusOptions?: ComponentProps<typeof WizSelectBox>["options"];
   statusPlaceholder?: string;
-  onChangeStatus?: (status: unknown) => void;
+  onChangeStatus?: (status: T) => void;
   onChangeTextValue: (value: string) => void;
   onSubmit: () => void;
   onToggle: () => void;
 };
 
-const ChatCard: FC<Props> = ({
+const ChatCard = <T,>({
   className,
   style,
   isOpen,
@@ -70,7 +69,7 @@ const ChatCard: FC<Props> = ({
   onChangeTextValue,
   onSubmit,
   onToggle,
-}) => {
+}:Props<T>) => {
   const wrapperBoxRef = useRef<HTMLDivElement>(null);
   const dividerRef = useRef<HTMLDivElement>(null);
   const listBoxRef = useRef<HTMLDivElement>(null);
@@ -194,7 +193,9 @@ const ChatCard: FC<Props> = ({
                 <WizSelectBox
                   options={statusOptions}
                   value={status}
-                  onChange={(selectedValue) => onChangeStatus?.(selectedValue)}
+                  onChange={(selectedValue) =>
+                    onChangeStatus?.(selectedValue as T)
+                  }
                   placeholder={statusPlaceholder}
                   expand
                 />

--- a/packages/wiz-ui-react/src/components/custom/chat/components/chat-card.tsx
+++ b/packages/wiz-ui-react/src/components/custom/chat/components/chat-card.tsx
@@ -43,10 +43,10 @@ type Props = BaseProps & {
   haveNewMessage?: boolean;
   formRows?: number;
   typingUsername?: string;
-  status?: number | null;
+  status?: unknown;
   statusOptions?: ComponentProps<typeof WizSelectBox>["options"];
   statusPlaceholder?: string;
-  onChangeStatus?: (status: number | null) => void;
+  onChangeStatus?: (status: unknown) => void;
   onChangeTextValue: (value: string) => void;
   onSubmit: () => void;
   onToggle: () => void;

--- a/packages/wiz-ui-react/src/components/custom/form/stories/all-input.tsx
+++ b/packages/wiz-ui-react/src/components/custom/form/stories/all-input.tsx
@@ -19,7 +19,7 @@ const TemplateComponent = ({
   args: ComponentProps<typeof WizFormGroup>;
   error?: string;
 }) => {
-  const [selectBoxValue, setSelectBoxValue] = useState<number | null>(null);
+  const [selectBoxValue, setSelectBoxValue] = useState<unknown | null>(null);
   const [checkBoxValues, setCheckBoxValues] = useState<number[]>([]);
   const [radioValue, setRadioValue] = useState<number | null>(null);
   const [timePickerValue, setTimePickerValue] =

--- a/packages/wiz-ui-react/src/components/custom/form/stories/all-input.tsx
+++ b/packages/wiz-ui-react/src/components/custom/form/stories/all-input.tsx
@@ -19,7 +19,7 @@ const TemplateComponent = ({
   args: ComponentProps<typeof WizFormGroup>;
   error?: string;
 }) => {
-  const [selectBoxValue, setSelectBoxValue] = useState<unknown | null>(null);
+  const [selectBoxValue, setSelectBoxValue] = useState<number | null>(null);
   const [checkBoxValues, setCheckBoxValues] = useState<number[]>([]);
   const [radioValue, setRadioValue] = useState<number | null>(null);
   const [timePickerValue, setTimePickerValue] =


### PR DESCRIPTION
# タスク

resolve: #1190 

## 行ったこと
- React で、Option の value を number → T型に修正
  - Selectbox などの一部のコンポーネントにて、デフォルト値を `value = -1` としている場合は number 型のままにした

## TODO
- [ ] Vue.js で、option の Value 型を number から T に変更
- [ ] Search Selector など、default 値が number で固定されているものについて Number 型に固定された箇所の修正

`generics` を利用して Vue.js の型定義を投げるようになったが、computed, methods の引数に型を渡せなかったため、別PR で対応した



https://ja.vuejs.org/api/sfc-script-setup#generics

<!-- reviewerにオーナーを追加してください-->
