### PR TITLE
Bug(search-input): チェックボックスの位置を調整

### DIFF
--- a/.changeset/yellow-weeks-march.md
+++ b/.changeset/yellow-weeks-march.md
@@ -1,0 +1,5 @@
+---
+"@wizleap-inc/wiz-ui-styles": patch
+---
+
+[#1210] Search Input の checkbox の位置調整のため、line-height を無効化

--- a/packages/styles/bases/search-input.css.ts
+++ b/packages/styles/bases/search-input.css.ts
@@ -189,7 +189,6 @@ export const searchCheckboxBlockCheckedStyle = style({
 });
 
 export const searchInputLabelStyle = style({
-  lineHeight: THEME.fontSize.xl3,
   width: "100%",
 });
 

--- a/packages/styles/bases/search-input.css.ts
+++ b/packages/styles/bases/search-input.css.ts
@@ -142,7 +142,7 @@ export const searchDropdownSelectingItemStyle = style({
 });
 
 export const searchDropdownCheckboxItemStyle = style({
-  padding: `${THEME.spacing.xs} ${THEME.spacing.xs2}`,
+  padding: `${THEME.spacing.sm} ${THEME.spacing.xs2}`,
 });
 
 export const searchCheckboxInputStyle = style({

--- a/packages/styles/bases/search-input.css.ts
+++ b/packages/styles/bases/search-input.css.ts
@@ -99,11 +99,11 @@ export const searchPopupBlockBorderRadiusStyle = style({
 });
 
 export const searchDropdownItemStyle = style({
-  padding: `${THEME.spacing.xs} ${THEME.spacing.no}`,
+  padding: `0.375rem ${THEME.spacing.no}`,
 });
 
 export const searchPopupDropdownItemStyle = style({
-  padding: `${THEME.spacing.xs} ${THEME.spacing.no}`,
+  padding: `${THEME.spacing.sm} ${THEME.spacing.no}`,
 });
 
 export const searchDropdownLabelStyle = style({

--- a/packages/styles/bases/search-input.css.ts
+++ b/packages/styles/bases/search-input.css.ts
@@ -99,6 +99,7 @@ export const searchPopupBlockBorderRadiusStyle = style({
 });
 
 export const searchDropdownItemStyle = style({
+  // FIXME: デザインシステムを使った値で再定義する
   padding: `0.375rem ${THEME.spacing.no}`,
 });
 

--- a/packages/wiz-ui-next/src/components/base/inputs/search-input/search-input.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/search-input/search-input.vue
@@ -42,6 +42,7 @@
             <!-- Dropdown -->
             <div v-if="item.children" :class="styles.searchDropdownItemStyle">
               <WizHStack
+                py="xs2"
                 align="center"
                 justify="between"
                 :class="[

--- a/packages/wiz-ui-next/src/components/base/inputs/search-input/search-popup.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/search-input/search-popup.vue
@@ -33,6 +33,7 @@
               :class="styles.searchPopupDropdownItemStyle"
             >
               <WizHStack
+                py="xs2"
                 align="center"
                 justify="between"
                 :class="[

--- a/packages/wiz-ui-react/src/components/base/inputs/search-input/components/search-popup-panel.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-input/components/search-popup-panel.tsx
@@ -90,6 +90,7 @@ export const SearchPopupPanel: FC<Props> = ({
                       )}
                     >
                       <WizHStack
+                        py="xs2"
                         width="100%"
                         justify="between"
                         align="center"


### PR DESCRIPTION
# タスク

resolve: #1210

## 行ったこと
- Search Input の Item の line-height を無効
- 無効化したことで、高さが変わった Item の調整

<!-- reviewerにオーナーを追加してください-->
