### PR TITLE
fix: popupの座標計算でvisualViewportを加味するように修正

### DIFF
--- a/.changeset/quiet-sheep-jump.md
+++ b/.changeset/quiet-sheep-jump.md
@@ -1,0 +1,7 @@
+---
+"@wizleap-inc/wiz-ui-react": patch
+"@wizleap-inc/wiz-ui-next": patch
+"@wizleap-inc/wiz-ui-icons": patch
+---
+
+fix: popup の座標計算で visualViewport を加味するように修正

--- a/packages/wiz-ui-next/src/components/base/popup/popup.vue
+++ b/packages/wiz-ui-next/src/components/base/popup/popup.vue
@@ -184,14 +184,21 @@ const existsFixedOrStickyParent = (
   return existsFixedOrStickyParent(el.parentElement);
 };
 
+const isFixed = computed(() => {
+  return existsFixedOrStickyParent(containerRef.value || null) ? true : false;
+});
+
 let removeScrollHandler: (() => void) | null = null;
 const onChangeIsOpen = (newValue: boolean) => {
   if (newValue) {
     togglePopup();
-    removeScrollHandler = useScroll(updateBodyPxInfo, containerRef.value);
+    removeScrollHandler = useScroll(
+      () => updateBodyPxInfo(isFixed.value),
+      containerRef.value
+    );
     nextTick(() => {
       updatePopupSize();
-      updateBodyPxInfo();
+      updateBodyPxInfo(isFixed.value);
     });
   } else {
     togglePopup();
@@ -211,7 +218,7 @@ useClickOutside(containerRef, (e) => {
   }
 });
 
-const observer = new ResizeObserver(updateBodyPxInfo);
+const observer = new ResizeObserver(() => updateBodyPxInfo(isFixed.value));
 observer.observe(document.body);
 
 const popupRect = computed(() => {
@@ -354,10 +361,6 @@ watch(
     emit("onTurn", newVal);
   }
 );
-
-const isFixed = computed(() => {
-  return existsFixedOrStickyParent(containerRef.value || null) ? true : false;
-});
 
 const inset = computed(() => {
   const { scrollX, scrollY } = isFixed.value

--- a/packages/wiz-ui-next/src/components/base/popup/provider.ts
+++ b/packages/wiz-ui-next/src/components/base/popup/provider.ts
@@ -22,15 +22,19 @@ export const usePopupProvider = (
   };
   const bodyPxInfo = reactive<PxInfo>(initialPxInfo);
 
-  const updateBodyPxInfo = () => {
+  const updateBodyPxInfo = (isPopupFixed: boolean) => {
     if (containerRef.value) {
       const { top, left, right, bottom, width, height } =
         containerRef.value.getBoundingClientRect();
+      const visualViewportOffset = {
+        top: isPopupFixed ? window.visualViewport?.offsetTop ?? 0 : 0,
+        left: isPopupFixed ? window.visualViewport?.offsetLeft ?? 0 : 0,
+      };
       Object.assign(bodyPxInfo, {
-        top,
-        left,
-        right,
-        bottom,
+        top: top + visualViewportOffset.top,
+        left: left + visualViewportOffset.left,
+        right: right + visualViewportOffset.left,
+        bottom: bottom + visualViewportOffset.top,
         width,
         height,
       });

--- a/packages/wiz-ui-react/src/components/base/popup/components/popup.tsx
+++ b/packages/wiz-ui-react/src/components/base/popup/components/popup.tsx
@@ -89,14 +89,13 @@ const Popup: FC<Props> = ({
     }
 
     const fontSize = window.getComputedStyle(document.body).fontSize;
-    const contentRect = popupRef.current.getBoundingClientRect();
 
     setPopupPosition(
       getPopupPosition({
         anchorRect: anchorElement.current.getBoundingClientRect(),
         popupSize: {
-          width: contentRect.width,
-          height: contentRect.height,
+          width: popupRef.current.clientWidth,
+          height: popupRef.current.clientHeight,
         },
         directionKey: direction,
         gap: parseFloat(getSpacingCss(gap) || "0") * parseFloat(fontSize),
@@ -109,6 +108,7 @@ const Popup: FC<Props> = ({
           y: isPopupFixed ? 0 : window.scrollY,
         },
         isDirectionFixed,
+        isPopupFixed,
       })
     );
   }, [anchorElement, direction, gap, isDirectionFixed, isPopupFixed]);

--- a/packages/wiz-ui-react/src/components/base/popup/components/popup.tsx
+++ b/packages/wiz-ui-react/src/components/base/popup/components/popup.tsx
@@ -108,7 +108,7 @@ const Popup: FC<Props> = ({
           y: isPopupFixed ? 0 : window.scrollY,
         },
         isDirectionFixed,
-        isPopupFixed,
+        visualViewport: isPopupFixed ? window.visualViewport : null,
       })
     );
   }, [anchorElement, direction, gap, isDirectionFixed, isPopupFixed]);

--- a/packages/wiz-ui-react/src/components/base/popup/utils/popup-position.ts
+++ b/packages/wiz-ui-react/src/components/base/popup/utils/popup-position.ts
@@ -26,24 +26,18 @@ export class Popup {
     screenSize: Size;
     scroll: Position;
     isDirectionFixed?: boolean;
-    isPopupFixed?: boolean;
+    visualViewport?: { offsetTop: number; offsetLeft: number } | null;
   }) {
-    const visualViewportOffset = {
-      top: window.visualViewport?.offsetTop ?? 0,
-      left: window.visualViewport?.offsetLeft ?? 0,
-    };
-    this.anchorRect = args.isPopupFixed
-      ? new DOMRect(
-          args.anchorRect.x + visualViewportOffset.left,
-          args.anchorRect.y + visualViewportOffset.top,
-          args.anchorRect.width,
-          args.anchorRect.height
-        )
-      : args.anchorRect;
+    this.anchorRect = new Rect(
+      args.anchorRect.x + (args.visualViewport?.offsetLeft ?? 0),
+      args.anchorRect.y + (args.visualViewport?.offsetTop ?? 0),
+      args.anchorRect.width,
+      args.anchorRect.height
+    );
     this.popupSize = args.popupSize;
     this.gap = args.gap;
     this.screenSize = args.screenSize;
-    this.scroll = args.isPopupFixed ? { x: 0, y: 0 } : args.scroll;
+    this.scroll = args.scroll;
     this.isDirectionFixed = args.isDirectionFixed ?? false;
   }
 
@@ -246,7 +240,7 @@ export function getPopupPosition({
   screenSize,
   scroll,
   isDirectionFixed,
-  isPopupFixed,
+  visualViewport,
 }: {
   anchorRect: Rect;
   popupSize: Size;
@@ -255,7 +249,7 @@ export function getPopupPosition({
   screenSize: Size;
   scroll: Position;
   isDirectionFixed?: boolean;
-  isPopupFixed?: boolean;
+  visualViewport?: { offsetTop: number; offsetLeft: number } | null;
 }): { top: number; left: number } {
   const popup = new Popup({
     anchorRect,
@@ -264,7 +258,7 @@ export function getPopupPosition({
     screenSize,
     scroll,
     isDirectionFixed,
-    isPopupFixed,
+    visualViewport,
   });
   return popup.getPosition(directionKey);
 }

--- a/packages/wiz-ui-react/src/components/base/popup/utils/popup-position.ts
+++ b/packages/wiz-ui-react/src/components/base/popup/utils/popup-position.ts
@@ -26,12 +26,24 @@ export class Popup {
     screenSize: Size;
     scroll: Position;
     isDirectionFixed?: boolean;
+    isPopupFixed?: boolean;
   }) {
-    this.anchorRect = args.anchorRect;
+    const visualViewportOffset = {
+      top: window.visualViewport?.offsetTop ?? 0,
+      left: window.visualViewport?.offsetLeft ?? 0,
+    };
+    this.anchorRect = args.isPopupFixed
+      ? new DOMRect(
+          args.anchorRect.x + visualViewportOffset.left,
+          args.anchorRect.y + visualViewportOffset.top,
+          args.anchorRect.width,
+          args.anchorRect.height
+        )
+      : args.anchorRect;
     this.popupSize = args.popupSize;
     this.gap = args.gap;
     this.screenSize = args.screenSize;
-    this.scroll = args.scroll;
+    this.scroll = args.isPopupFixed ? { x: 0, y: 0 } : args.scroll;
     this.isDirectionFixed = args.isDirectionFixed ?? false;
   }
 
@@ -234,6 +246,7 @@ export function getPopupPosition({
   screenSize,
   scroll,
   isDirectionFixed,
+  isPopupFixed,
 }: {
   anchorRect: Rect;
   popupSize: Size;
@@ -242,6 +255,7 @@ export function getPopupPosition({
   screenSize: Size;
   scroll: Position;
   isDirectionFixed?: boolean;
+  isPopupFixed?: boolean;
 }): { top: number; left: number } {
   const popup = new Popup({
     anchorRect,
@@ -250,6 +264,7 @@ export function getPopupPosition({
     screenSize,
     scroll,
     isDirectionFixed,
+    isPopupFixed,
   });
   return popup.getPosition(directionKey);
 }


### PR DESCRIPTION
# タスク

resolve: #1100 

<!-- reviewerにオーナーを追加してください-->


## 原因

safari の場合のみ、ピンチズーム時に `position: fixed` な要素の `getBoundingClientRect()` で得られる座標がずれる（safari のバグ）
https://bugs.webkit.org/show_bug.cgi?id=207089

## 対策

`window.visualViewport` の値を加味して座標を補正する