### PR TITLE
Feat(tooltip): contentが空のときにtooltipを表示しない

### DIFF
--- a/.changeset/blue-kangaroos-play.md
+++ b/.changeset/blue-kangaroos-play.md
@@ -1,0 +1,5 @@
+---
+"@wizleap-inc/wiz-ui-react": patch
+---
+
+[#1258] feat: tooltip にて、content がなければ Popup が表示されないように修正

--- a/packages/wiz-ui-next/src/components/base/tooltip/tooltip.vue
+++ b/packages/wiz-ui-next/src/components/base/tooltip/tooltip.vue
@@ -18,6 +18,7 @@
         :isDirectionFixed="isDirectionFixed"
       >
         <div
+          v-if="hasContent"
           :class="[tooltipPositionStyle[actuallyDirection], tooltipPopupStyle]"
         >
           <div :class="tooltipContentStyle">
@@ -45,7 +46,7 @@ import {
   tooltipPositionStyle,
   tooltipPopupStyle,
 } from "@wizleap-inc/wiz-ui-styles/bases/tooltip.css";
-import { PropType, ref, computed } from "vue";
+import { PropType, ref, computed, useSlots } from "vue";
 
 import { WizIChangeHistory, WizPopup, WizPopupContainer } from "@/components";
 
@@ -78,6 +79,10 @@ const props = defineProps({
 
 const isHover = ref(false);
 const actuallyDirection = ref(props.direction);
+
+const slots = useSlots();
+const getSlots = slots.content?.() ?? [];
+const hasContent = getSlots.length > 0;
 
 const computedDirection = computed(() => {
   if (props.direction === "top") return "tc";

--- a/packages/wiz-ui-react/src/components/base/tooltip/components/tooltip.tsx
+++ b/packages/wiz-ui-react/src/components/base/tooltip/components/tooltip.tsx
@@ -17,7 +17,7 @@ type Props = BaseProps & {
   isOpen?: boolean;
   isDirectionFixed?: boolean;
   children: ReactNode;
-  content: ReactNode;
+  content?: ReactNode;
   expand?: boolean;
 };
 
@@ -34,6 +34,10 @@ const Tooltip: FC<Props> = ({
   const [isHover, setIsHover] = useState(false);
   const anchor = useRef<HTMLDivElement | null>(null);
 
+  const handleClose = useCallback(() => {
+    setIsHover(false);
+  }, []);
+
   return (
     <>
       <div
@@ -48,30 +52,32 @@ const Tooltip: FC<Props> = ({
       >
         {children}
       </div>
-      <WizPopup
-        anchorElement={anchor}
-        isOpen={isHover || isOpen}
-        onClose={useCallback(() => setIsHover(false), [])}
-        direction={direction}
-        shadow={false}
-        animation
-        gap="xs2"
-        isDirectionFixed={isDirectionFixed}
-      >
-        <div
-          className={clsx(tooltipPositionStyle[direction], tooltipPopupStyle)}
+      {content && (
+        <WizPopup
+          anchorElement={anchor}
+          isOpen={isHover || isOpen}
+          onClose={handleClose}
+          direction={direction}
+          shadow={false}
+          animation
+          gap="xs2"
+          isDirectionFixed={isDirectionFixed}
         >
-          <div className={clsx(tooltipContentStyle)}>{content}</div>
           <div
-            className={clsx(
-              tooltipIconStyle,
-              tooltipIconDirectionStyle[direction]
-            )}
+            className={clsx(tooltipPositionStyle[direction], tooltipPopupStyle)}
           >
-            <WizIChangeHistory />
+            <div className={clsx(tooltipContentStyle)}>{content}</div>
+            <div
+              className={clsx(
+                tooltipIconStyle,
+                tooltipIconDirectionStyle[direction]
+              )}
+            >
+              <WizIChangeHistory />
+            </div>
           </div>
-        </div>
-      </WizPopup>
+        </WizPopup>
+      )}
     </>
   );
 };


### PR DESCRIPTION
# タスク

resolve: #1258

## 行なったこと
- React にて、 content が空のときに tooltip が表示されないように修正
- Vue では、すでに対応済み

```vue
 <WizPopup
  v-if="$slots.content"
  :isOpen="isHover || isOpen"
  :direction="computedDirection"
  :shadow="false"
  :animation="true"
  @onTurn="turnPopup"
  gap="xs2"
  :isDirectionFixed="isDirectionFixed"
>
```

<!-- reviewerにオーナーを追加してください-->
