### PR TITLE
Feat(wiz-text): blurがかかったときにuser-select: noneを有効にする

### DIFF
--- a/.changeset/old-socks-cheat.md
+++ b/.changeset/old-socks-cheat.md
@@ -1,0 +1,5 @@
+---
+"@wizleap-inc/wiz-ui-styles": patch
+---
+
+[#1259] feat: text の dummyText にて、user-select: none を適用

--- a/packages/styles/bases/text.css.ts
+++ b/packages/styles/bases/text.css.ts
@@ -42,6 +42,7 @@ export const textWordBreakStyle = style({
 
 export const textDummyStyle = style({
   filter: `blur(${THEME.spacing.xs2})`,
+  userSelect: "none",
 });
 
 export const textLineThroughStyle = style({


### PR DESCRIPTION
# タスク

resolve: #1259 

## 行なったこと
- DummyText にて、 user-select: none を適用した


<!-- reviewerにオーナーを追加してください-->
