### PR TITLE
Feat: select系をジェネリックコンポーネントにする

### DIFF
--- a/.changeset/eleven-kangaroos-grow.md
+++ b/.changeset/eleven-kangaroos-grow.md
@@ -1,0 +1,6 @@
+---
+"@wizleap-inc/wiz-ui-next": minor
+"@wizleap-inc/wiz-ui-example-vue3": minor
+---
+
+Feat: select 系をジェネリックコンポーネント化する

--- a/examples/vue3/package.json
+++ b/examples/vue3/package.json
@@ -15,8 +15,8 @@
     "vue": "^3.4.21"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^4.1.0",
+    "@vitejs/plugin-vue": "^5.0.4",
     "vue-router": "^4.1.6",
-    "vue-tsc": "^2.0.7"
+    "vue-tsc": "^1.8.27"
   }
 }

--- a/examples/vue3/package.json
+++ b/examples/vue3/package.json
@@ -9,14 +9,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "vue": "^3.2.45",
+    "@wizleap-inc/wiz-ui-constants": "workspace:",
     "@wizleap-inc/wiz-ui-next": "workspace:",
     "@wizleap-inc/wiz-ui-utils": "workspace:",
-    "@wizleap-inc/wiz-ui-constants": "workspace:"
+    "vue": "^3.4.21"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^3.2.0",
+    "@vitejs/plugin-vue": "^4.1.0",
     "vue-router": "^4.1.6",
-    "vue-tsc": "^1.0.9"
+    "vue-tsc": "^2.0.7"
   }
 }

--- a/examples/vue3/src/pages/chat/_components/chat-form.vue
+++ b/examples/vue3/src/pages/chat/_components/chat-form.vue
@@ -72,7 +72,7 @@ const props = defineProps({
     required: false,
   },
   statusOptions: {
-    type: Array as PropType<SelectBoxOption[]>,
+    type: Array as PropType<SelectBoxOption<number>[]>,
     required: false,
   },
   statusPlaceholder: {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-unused-imports": "^2.0.0",
-    "eslint-plugin-vue": "^9.7.0",
+    "eslint-plugin-vue": "^9.23.0",
     "http-server": "^14.1.1",
     "husky": "^8.0.2",
     "jsdom": "^21.1.1",

--- a/packages/styles/bases/search-input.css.ts
+++ b/packages/styles/bases/search-input.css.ts
@@ -1,4 +1,4 @@
-import { globalStyle, style } from "@vanilla-extract/css";
+import { style } from "@vanilla-extract/css";
 import { THEME } from "@wizleap-inc/wiz-ui-constants";
 
 const borderWidth = "1px";
@@ -45,14 +45,6 @@ export const searchInputIconStyle = style({
   fill: THEME.color.gray["400"],
 });
 
-export const searchContainerStyle = style({
-  position: "absolute",
-});
-
-export const searchPopupStyle = style({
-  display: "flex",
-});
-
 export const searchBlockStyle = style({
   backgroundColor: THEME.color.white[800],
   paddingRight: THEME.spacing.xs,
@@ -76,35 +68,9 @@ export const searchBlockBorderRadiusStyle = style({
   borderRadius: `${THEME.spacing.xs2} ${THEME.spacing.no} ${THEME.spacing.no} ${THEME.spacing.xs2}`,
 });
 
-export const searchPopupBlockStyle = style({
-  backgroundColor: THEME.color.white[800],
-  padding: `${THEME.spacing.no} ${THEME.spacing.xs}`,
-  height: "25rem",
-  overflowY: "auto",
-  "::-webkit-scrollbar": {
-    width: THEME.spacing.xs2,
-  },
-  "::-webkit-scrollbar-thumb": {
-    backgroundColor: THEME.color.gray[400],
-    borderRadius: THEME.spacing.xs,
-  },
-});
-
-export const searchPopupBlockBorderRightStyle = style({
-  borderRight: `${borderWidth} solid ${THEME.color.gray["400"]}`,
-});
-
-export const searchPopupBlockBorderRadiusStyle = style({
-  borderRadius: `${THEME.spacing.no} ${THEME.spacing.xs2} ${THEME.spacing.xs2} ${THEME.spacing.no}`,
-});
-
 export const searchDropdownItemStyle = style({
   // FIXME: デザインシステムを使った値で再定義する
   padding: `0.375rem ${THEME.spacing.no}`,
-});
-
-export const searchPopupDropdownItemStyle = style({
-  padding: `${THEME.spacing.sm} ${THEME.spacing.no}`,
 });
 
 export const searchDropdownLabelStyle = style({
@@ -146,55 +112,6 @@ export const searchDropdownCheckboxItemStyle = style({
   padding: `${THEME.spacing.sm} ${THEME.spacing.xs2}`,
 });
 
-export const searchCheckboxInputStyle = style({
-  display: "none",
-});
-
-export const searchCheckboxLabelStyle = style({
-  position: "relative",
-  display: "flex",
-  alignItems: "center",
-  color: THEME.color.gray["800"],
-  lineHeight: THEME.fontSize.xl3,
-  fontSize: THEME.fontSize.sm,
-  gap: THEME.spacing.sm,
-  cursor: "pointer",
-  ":before": {
-    content: "",
-    border: `${borderWidth} solid ${THEME.color.gray["400"]}`,
-    borderRadius: `calc(${THEME.spacing.xs2} / 2)`,
-    width: THEME.spacing.md,
-    height: THEME.spacing.md,
-    boxSizing: "border-box",
-    display: "inline-block",
-    flexShrink: 0,
-  },
-});
-
-export const searchCheckboxLabelCheckedStyle = style({
-  ":before": {
-    border: `${borderWidth} solid ${THEME.color.green["800"]}`,
-  },
-});
-
-export const searchCheckboxIconStyle = style({
-  position: "absolute",
-  top: "50%",
-  transform: "translateY(-50%)",
-  left: borderWidth,
-  fill: THEME.color.green["800"],
-});
-
-export const searchCheckboxBlockCheckedStyle = style({
-  color: THEME.color.green["800"],
-});
-
 export const searchInputLabelStyle = style({
-  width: "100%",
-});
-
-export const searchInputCheckboxStyle = style({});
-// FIXME: WizCheckBoxNewで置換する際に消す。
-globalStyle(`${searchInputCheckboxStyle} > div`, {
   width: "100%",
 });

--- a/packages/wiz-ui-next/package.json
+++ b/packages/wiz-ui-next/package.json
@@ -15,9 +15,9 @@
   "devDependencies": {
     "@storybook/vue3": "^7.0.2",
     "@storybook/vue3-vite": "^7.0.2",
-    "@vitejs/plugin-vue": "^4.1.0",
+    "@vitejs/plugin-vue": "^5.0.4",
     "unplugin-vue-define-options": "^1.1.1",
-    "vue-tsc": "^2.0.7"
+    "vue-tsc": "^1.8.27"
   },
   "repository": {
     "type": "git",

--- a/packages/wiz-ui-next/package.json
+++ b/packages/wiz-ui-next/package.json
@@ -13,11 +13,11 @@
     "storybook:test": "concurrently -k -s first -n \"SB,TEST\" -c \"magenta,blue\" \"NODE_OPTIONS=--max_old_space_size=4096 storybook build --quiet && npx http-server storybook-static --port 6007 --silent\" \"wait-on tcp:6007 && test-storybook --url http://localhost:6007\""
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^4.1.0",
-    "unplugin-vue-define-options": "^1.1.1",
     "@storybook/vue3": "^7.0.2",
     "@storybook/vue3-vite": "^7.0.2",
-    "vue-tsc": "^1.0.9"
+    "@vitejs/plugin-vue": "^4.1.0",
+    "unplugin-vue-define-options": "^1.1.1",
+    "vue-tsc": "^2.0.7"
   },
   "repository": {
     "type": "git",
@@ -35,7 +35,7 @@
     "@wizleap-inc/wiz-ui-constants": "workspace:*",
     "@wizleap-inc/wiz-ui-styles": "workspace:*",
     "@wizleap-inc/wiz-ui-utils": "workspace:*",
-    "vue": "^3.2.45",
+    "vue": "^3.4.21",
     "vue-router": "^4.1.6"
   }
 }

--- a/packages/wiz-ui-next/src/components/base/inputs/search-input/search-input.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/search-input/search-input.vue
@@ -125,7 +125,7 @@
   </WizPopupContainer>
 </template>
 
-<script setup lang="ts">
+<script setup lang="ts" generic="T">
 import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
 import * as styles from "@wizleap-inc/wiz-ui-styles/bases/search-input.css";
 import { inputBorderStyle } from "@wizleap-inc/wiz-ui-styles/commons";
@@ -152,7 +152,7 @@ defineOptions({
 
 const props = defineProps({
   options: {
-    type: Array as PropType<SearchInputOption[]>,
+    type: Array as PropType<SearchInputOption<T>[]>,
     required: true,
   },
   modelValue: {
@@ -217,7 +217,7 @@ const checkValues = computed({
 });
 
 const searchValue = ref("");
-const filteredOptions = ref<SearchInputOption[]>([]);
+const filteredOptions = ref<SearchInputOption<T>[]>([]);
 const selectedItem = ref<number[]>([]);
 const activeItem = ref<number | null>();
 const activeItemIndex = ref<number | null>(null);
@@ -262,7 +262,7 @@ const handleClickCheckbox = (value: number) => {
 
 const filterOptions =
   (match: (label: string) => boolean) =>
-  (options: SearchInputOption[]): SearchInputOption[] =>
+  (options: SearchInputOption<T>[]): SearchInputOption<T>[] =>
     options.flatMap((option) => {
       const isMatched = match(option.label);
       if (!option.children || option.children.length === 0) {

--- a/packages/wiz-ui-next/src/components/base/inputs/search-input/search-input.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/search-input/search-input.vue
@@ -25,95 +25,7 @@
       @onClose="emit('toggle', false)"
       :isDirectionFixed="isDirectionFixed"
     >
-      <WizHStack>
-        <div
-          v-if="filteredOptions.length"
-          :class="[
-            styles.searchBlockStyle,
-            styles.searchBlockBorderRadiusStyle,
-            isBorder && styles.searchBlockBorderStyle,
-          ]"
-          :style="{ width: computedPopupWidth }"
-        >
-          <div
-            v-for="(item, key) in filteredOptions"
-            :key="`${item.label}_${item.value}_${key}`"
-          >
-            <!-- Dropdown -->
-            <div v-if="item.children" :class="styles.searchDropdownItemStyle">
-              <WizHStack
-                py="xs2"
-                align="center"
-                justify="between"
-                :class="[
-                  styles.searchDropdownLabelStyle,
-                  // selectedItem?.includes(item.value) &&
-                  isItemSelected(item.value) &&
-                    styles.searchDropdownSelectingItemStyle,
-                ]"
-                @mouseover="onMouseover(item.value)"
-                @mouseout="activeItem = null"
-              >
-                <WizHStack
-                  width="100%"
-                  justify="between"
-                  align="center"
-                  nowrap
-                  gap="xs2"
-                >
-                  <div :class="styles.searchInputLabelStyle">
-                    {{ item.label }}
-                  </div>
-                  <WizHStack gap="xs" nowrap>
-                    <template v-if="item.tag">
-                      <WizTag
-                        :label="item.tag.label"
-                        variant="white"
-                        width="20px"
-                        font-size="xs2"
-                      />
-                    </template>
-                    <WizIcon
-                      size="xl2"
-                      :icon="WizIChevronRight"
-                      :color="computedIconColor(item.value)"
-                    />
-                  </WizHStack>
-                </WizHStack>
-              </WizHStack>
-            </div>
-            <!-- Checkbox -->
-            <div
-              v-else
-              :class="styles.searchDropdownCheckboxItemStyle"
-              @mouseover="activeItem = item.value"
-              @mouseout="activeItem = null"
-            >
-              <WizCheckBoxNew
-                :style="{ width: '100%' }"
-                :checked="checkValuesUnwrapRef.includes(item.value)"
-                :value="item.value"
-                :id="`${item.label}_${item.value}`"
-                @update:checked="handleClickCheckbox(item.value)"
-              >
-                <WizHStack width="100%" align="center" nowrap gap="xs2">
-                  <div :class="styles.searchInputLabelStyle">
-                    {{ item.label }}
-                  </div>
-                  <template v-if="item.tag">
-                    <WizTag
-                      :label="item.tag.label"
-                      variant="white"
-                      width="20px"
-                      font-size="xs2"
-                    />
-                  </template>
-                </WizHStack>
-              </WizCheckBoxNew>
-            </div>
-            <WizDivider color="gray.300" />
-          </div>
-        </div>
+      <WizHStack nowrap>
         <WizSearchPopup
           v-model="checkValuesUnwrapRef"
           :options="filteredOptions"
@@ -130,12 +42,10 @@
 import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
 import * as styles from "@wizleap-inc/wiz-ui-styles/bases/search-input.css";
 import { inputBorderStyle } from "@wizleap-inc/wiz-ui-styles/commons";
-import { UnwrapRef, computed, onMounted, ref, watch } from "vue";
+import { UnwrapRef, computed, ref } from "vue";
 
 import {
-  WizCheckBoxNew,
   WizHStack,
-  WizIChevronRight,
   WizISearch,
   WizPopup,
   WizPopupContainer,
@@ -178,76 +88,28 @@ type Emits = {
   click: [];
 };
 const emit = defineEmits<Emits>();
-// const emit = defineEmits<{
-//   "update:modelValue": [value: UnwrapRef<T>[]];
-//   toggle: [value: boolean];
-//   click: [];
-// }>();
-
-// const checkValues = computed({
-//   get: () => props.modelValue,
-//   set: (value: T[]) => emit("update:modelValue", value as T[]),
-// });
 
 const checkValuesUnwrapRef = computed({
   get: () => props.modelValue as UnwrapRef<T>[],
   set: (value: UnwrapRef<T>[]) => emit("update:modelValue", value as T[]),
 });
 
-// const checkedValues = ref<T[]>(props.modelValue);
-// const checkedValues = computed(() => props.modelValue);
-
 const searchValue = ref("");
-const filteredOptions = ref<SearchInputOption<T>[]>([]);
 const selectedItem = ref<T[] | null>();
-// const selectedItem = computed(() => props.modelValue);
-const activeItem = ref<UnwrapRef<T> | null>();
-const activeItemIndex = ref<number | null>(null);
 const hasFocus = ref(false);
-const isBorder = ref(false);
 
 const state = computed(() => {
-  if (hasFocus.value) return "active";
-  return "default";
+  return hasFocus.value ? "active" : "default";
 });
 
 const computedInputWidth = computed(() =>
   props.expand ? "100%" : props.inputWidth
 );
 const computedPopupWidth = computed(() => props.popupWidth);
-const computedIconColor = computed(() => (value: UnwrapRef<T>) => {
-  const v = value as T;
-  return activeItem.value === v ? "green.800" : "gray.500";
-});
-
-const isItemSelected = (value: UnwrapRef<T>) =>
-  selectedItem.value?.includes(value as T);
-
-const onMouseover = (value: UnwrapRef<T>) => {
-  isBorder.value = true;
-  activeItem.value = value;
-  activeItemIndex.value = filteredOptions.value.findIndex(
-    (option) => option.value === value
-  );
-  selectedItem.value = [];
-  if (!selectedItem.value.includes(value as T)) {
-    selectedItem.value.push(value as T);
-  }
-};
 
 const selectedItems = computed(
   () => (selectedItem.value ?? []) as UnwrapRef<T>[]
 );
-
-const handleClickCheckbox = (value: UnwrapRef<T>) => {
-  if (checkValuesUnwrapRef.value.includes(value)) {
-    checkValuesUnwrapRef.value = checkValuesUnwrapRef.value.filter(
-      (v) => v !== value
-    );
-  } else {
-    checkValuesUnwrapRef.value = [...checkValuesUnwrapRef.value, value];
-  }
-};
 
 const filterOptions =
   (match: (label: string) => boolean) =>
@@ -270,18 +132,11 @@ const filterOptions =
 
 const searchBy = (keyword: string) => (str: string) => str.includes(keyword);
 
-watch(searchValue, () => {
-  selectedItem.value = [];
-  emit("toggle", true);
+const filteredOptions = computed(() => {
   if (searchValue.value.length) {
     const opts = filterOptions(searchBy(searchValue.value))(props.options);
-    filteredOptions.value = opts as UnwrapRef<SearchInputOption<T>[]>;
-  } else {
-    filteredOptions.value = props.options as UnwrapRef<SearchInputOption<T>[]>;
+    return opts as UnwrapRef<SearchInputOption<T>[]>;
   }
-});
-
-onMounted(() => {
-  filteredOptions.value = props.options as UnwrapRef<SearchInputOption<T>[]>;
+  return props.options as UnwrapRef<SearchInputOption<T>[]>;
 });
 </script>

--- a/packages/wiz-ui-next/src/components/base/inputs/search-input/search-input.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/search-input/search-input.vue
@@ -129,7 +129,7 @@
 import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
 import * as styles from "@wizleap-inc/wiz-ui-styles/bases/search-input.css";
 import { inputBorderStyle } from "@wizleap-inc/wiz-ui-styles/commons";
-import { PropType, computed, onMounted, ref, watch } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 
 import {
   WizCheckBoxNew,
@@ -150,65 +150,32 @@ defineOptions({
   name: ComponentName.SearchInput,
 });
 
-const props = defineProps({
-  options: {
-    type: Array as PropType<SearchInputOption<T>[]>,
-    required: true,
-  },
-  modelValue: {
-    type: Array as PropType<number[]>,
-    required: true,
-  },
-  name: {
-    type: String,
-    required: true,
-  },
-  placeholder: {
-    type: String,
-    required: false,
-  },
-  disabled: {
-    type: Boolean,
-    required: false,
-  },
-  expand: {
-    type: Boolean,
-    required: false,
-  },
-  inputWidth: {
-    type: String,
-    required: false,
-    default: "10rem",
-  },
-  popupWidth: {
-    type: String,
-    required: false,
-  },
-  openPopup: {
-    type: Boolean,
-    required: true,
-  },
-  isDirectionFixed: {
-    type: Boolean,
-    required: false,
-    default: false,
-  },
-  icon: {
-    type: Object as PropType<TIcon>,
-    required: false,
-    default: WizISearch,
-  },
-  emptyMessage: {
-    type: String,
-    required: false,
-    default: "選択肢がありません。",
-  },
+type Props<T> = {
+  options: SearchInputOption<T>[];
+  modelValue: number[];
+  name: string;
+  placeholder?: string;
+  disabled?: boolean;
+  expand?: boolean;
+  inputWidth?: string;
+  popupWidth?: string;
+  openPopup: boolean;
+  isDirectionFixed?: boolean;
+  icon?: TIcon;
+  emptyMessage?: string;
+};
+
+const props = withDefaults(defineProps<Props<T>>(), {
+  inputWidth: "10rem",
+  isDirectionFixed: false,
+  icon: WizISearch,
+  emptyMessage: "選択肢がありません。",
 });
 
 const emit = defineEmits<{
-  (e: "update:modelValue", value: number[]): void;
-  (e: "click"): void;
-  (e: "toggle", value: boolean): void;
+  "update:modelValue": [value: number[]];
+  toggle: [value: boolean];
+  click: [];
 }>();
 
 const checkValues = computed({

--- a/packages/wiz-ui-next/src/components/base/inputs/search-input/search-input.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/search-input/search-input.vue
@@ -27,7 +27,7 @@
     >
       <WizHStack nowrap>
         <WizSearchPopup
-          v-model="checkValuesUnwrapRef"
+          v-model="checkValues"
           :options="filteredOptions"
           :selectedItem="selectedItems"
           :popupWidth="computedPopupWidth"
@@ -42,7 +42,7 @@
 import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
 import * as styles from "@wizleap-inc/wiz-ui-styles/bases/search-input.css";
 import { inputBorderStyle } from "@wizleap-inc/wiz-ui-styles/commons";
-import { UnwrapRef, computed, ref } from "vue";
+import { computed, ref } from "vue";
 
 import {
   WizHStack,
@@ -89,9 +89,9 @@ type Emits = {
 };
 const emit = defineEmits<Emits>();
 
-const checkValuesUnwrapRef = computed({
-  get: () => props.modelValue as UnwrapRef<T>[],
-  set: (value: UnwrapRef<T>[]) => emit("update:modelValue", value as T[]),
+const checkValues = computed({
+  get: () => props.modelValue,
+  set: (value: T[]) => emit("update:modelValue", value),
 });
 
 const searchValue = ref("");
@@ -107,9 +107,7 @@ const computedInputWidth = computed(() =>
 );
 const computedPopupWidth = computed(() => props.popupWidth);
 
-const selectedItems = computed(
-  () => (selectedItem.value ?? []) as UnwrapRef<T>[]
-);
+const selectedItems = computed(() => selectedItem.value ?? []);
 
 const filterOptions =
   (match: (label: string) => boolean) =>
@@ -135,8 +133,8 @@ const searchBy = (keyword: string) => (str: string) => str.includes(keyword);
 const filteredOptions = computed(() => {
   if (searchValue.value.length) {
     const opts = filterOptions(searchBy(searchValue.value))(props.options);
-    return opts as UnwrapRef<SearchInputOption<T>[]>;
+    return opts;
   }
-  return props.options as UnwrapRef<SearchInputOption<T>[]>;
+  return props.options;
 });
 </script>

--- a/packages/wiz-ui-next/src/components/base/inputs/search-input/search-popup.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/search-input/search-popup.vue
@@ -1,135 +1,118 @@
 <template>
-  <template v-for="(option, key) in options">
-    <div
-      v-if="option.children && selectedItem.includes(option.value)"
-      :class="styles.searchPopupStyle"
-      :key="`${option.label}_${option.value}_${key}`"
-    >
-      <div
-        ref="optionsRef"
-        @scroll="() => onScroll(key)"
-        :class="[
-          styles.searchPopupBlockStyle,
-          isBorder(option.children) && styles.searchPopupBlockBorderRightStyle,
-          !isBorder(option.children) &&
-            styles.searchPopupBlockBorderRadiusStyle,
-        ]"
-        :style="{ width: computedPopupWidth }"
+  <div
+    :class="[
+      styles.searchBlockStyle,
+      styles.searchBlockBorderRadiusStyle,
+      isOpen && styles.searchBlockBorderStyle,
+    ]"
+    :style="{ width: computedPopupWidth }"
+  >
+    <template v-if="options.length > 0">
+      <template
+        v-for="(option, key) in options"
+        :key="`${option.label}_${option.value}_${key}`"
       >
+        <!-- Dropdown -->
         <div
-          v-if="option.children.length === 0"
-          :class="[styles.searchDropdownEmptyMessageStyle]"
+          v-if="option.children"
+          :class="styles.searchDropdownItemStyle"
+          @mouseover="onMouseover(option.value, option.children)"
         >
-          {{ emptyMessage }}
-        </div>
-        <div v-else>
           <div
-            v-for="(item, key) in option.children"
-            :key="`${item.label}_${item.value}_${key}`"
+            :class="[
+              styles.searchDropdownLabelStyle,
+              activeOption &&
+                activeOption.value === option.value &&
+                styles.searchDropdownSelectingItemStyle,
+            ]"
           >
-            <!-- Dropdown -->
-            <div
-              v-if="item.children"
-              :class="styles.searchPopupDropdownItemStyle"
+            <WizHStack
+              py="xs2"
+              width="100%"
+              justify="between"
+              align="center"
+              gap="xs2"
+              nowrap
             >
-              <WizHStack
-                py="xs2"
-                align="center"
-                justify="between"
-                :class="[
-                  styles.searchDropdownLabelStyle,
-                  selectedItem.includes(item.value) &&
-                    styles.searchDropdownSelectingItemStyle,
-                ]"
-                @mouseover="onMouseover(item.value, option.children)"
-                @mouseout="activeItem = null"
-              >
-                <WizHStack
-                  width="100%"
-                  justify="between"
-                  align="center"
-                  nowrap
-                  gap="xs2"
-                >
-                  <div :class="styles.searchInputLabelStyle">
-                    {{ item.label }}
-                  </div>
-                  <WizHStack gap="xs" :width="item.tag ? '70px' : '24px'">
-                    <template v-if="item.tag">
-                      <WizTag
-                        :label="item.tag.label"
-                        variant="white"
-                        width="20px"
-                        font-size="xs2"
-                      />
-                    </template>
-                    <WizIcon
-                      size="xl2"
-                      :icon="WizIChevronRight"
-                      :color="computedIconColor(item.value)"
-                    />
-                  </WizHStack>
-                </WizHStack>
+              <div :class="styles.searchInputLabelStyle">
+                {{ option.label }}
+              </div>
+
+              <WizHStack gap="xs" nowrap>
+                <WizTag
+                  v-if="option.tag"
+                  :label="option.tag.label"
+                  variant="white"
+                  width="20px"
+                  font-size="xs2"
+                />
+                <WizIcon
+                  size="xl2"
+                  :icon="WizIChevronRight"
+                  :color="computedIconColor(option.value)"
+                />
               </WizHStack>
-            </div>
-            <!-- Checkbox -->
-            <div
-              v-else
-              :class="styles.searchDropdownCheckboxItemStyle"
-              @mouseover="activeItem = item.value"
-              @mouseout="activeItem = null"
-            >
-              <WizCheckBoxNew
-                :style="{ width: '100%' }"
-                :checked="checkValues.includes(item.value)"
-                :value="item.value"
-                :id="`${item.label}_${item.value}`"
-                @update:checked="handleClickCheckbox(item.value)"
-              >
-                <WizHStack width="100%" align="center" nowrap gap="xs2">
-                  <div :class="styles.searchInputLabelStyle">
-                    {{ item.label }}
-                  </div>
-                  <template v-if="item.tag">
-                    <WizTag
-                      :label="item.tag.label"
-                      variant="white"
-                      width="20px"
-                      font-size="xs2"
-                    />
-                  </template>
-                </WizHStack>
-              </WizCheckBoxNew>
-            </div>
-            <WizDivider color="gray.300" />
+            </WizHStack>
           </div>
         </div>
+        <!-- Checkbox -->
+        <div v-else>
+          <div :class="styles.searchDropdownCheckboxItemStyle">
+            <WizCheckBoxNew
+              :style="{ width: '100%' }"
+              :checked="checkValues.includes(option.value)"
+              :value="option.value"
+              :id="`${option.label}_${option.value}`"
+              @update:checked="handleClickCheckbox(option.value)"
+            >
+              <WizHStack width="100%" align="center" nowrap gap="xs2">
+                <div :class="styles.searchInputLabelStyle">
+                  {{ option.label }}
+                </div>
+                <WizTag
+                  v-if="option.tag"
+                  :label="option.tag.label"
+                  variant="white"
+                  width="20px"
+                  font-size="xs2"
+                />
+              </WizHStack>
+            </WizCheckBoxNew>
+          </div>
+        </div>
+        <WizDivider color="gray.300" />
+      </template>
+    </template>
+    <template v-else>
+      <div :class="[styles.searchDropdownEmptyMessageStyle]">
+        {{ emptyMessage }}
       </div>
-      <WizSearchPopup
-        v-model="checkValues"
-        :options="option.children"
-        :selectedItem="selectedItem"
-        :popupWidth="computedPopupWidth"
-        :emptyMessage="emptyMessage"
-      />
-    </div>
-  </template>
+    </template>
+  </div>
+  <WizSearchPopup
+    v-if="isOpen"
+    v-model="checkValues"
+    :options="activeOptionChildren ?? []"
+    :selectedItem="selectedItem"
+    :popupWidth="computedPopupWidth"
+    :emptyMessage="emptyMessage"
+  />
 </template>
 
 <script setup lang="ts" generic="T extends CheckboxOption">
 import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
 import * as styles from "@wizleap-inc/wiz-ui-styles/bases/search-input.css";
-import { UnwrapRef, computed, ref, watch } from "vue";
+import { computed, ref } from "vue";
 
 import {
   WizCheckBoxNew,
   WizDivider,
   WizHStack,
+  WizIChevronRight,
   WizIcon,
   WizSearchPopup,
   WizTag,
 } from "@/components";
-import { WizIChevronRight } from "@/components/icons";
 
 import { CheckboxOption, SearchInputOption } from "./types";
 
@@ -153,59 +136,19 @@ type Emits<T extends CheckboxOption> = {
 const emit = defineEmits<Emits<T>>();
 
 const activeItem = ref<T | null>();
-const activeItemIndex = ref<number | null>(null);
+const activeOption = computed(() => {
+  return props.options.find((option) => option.value === activeItem.value);
+});
+const activeOptionChildren = computed(() => {
+  return activeOption.value?.children;
+});
+const isOpen = computed(() => activeOptionChildren.value !== undefined);
 
-const ITEM_HEIGHT = 44;
-const DIVIDER_HEIGHT = 0.8;
+const activeItemIndex = ref<number | null>(null);
 
 const checkValues = computed({
   get: () => props.modelValue,
   set: (value) => emit("update:modelValue", value),
-});
-
-const mutableSelectedItem = computed(() => {
-  return props.selectedItem;
-});
-
-const optionsRef = ref<HTMLElement[]>();
-const scrollAmount = ref<number>(0);
-const scrollItems = ref<SearchInputOption<T>[]>([]);
-const onScroll = (parentOrder: number) => {
-  scrollAmount.value = optionsRef.value?.[0].scrollTop || 0;
-  // scrollItems.value = props.options[parentOrder].children ?? null;
-  scrollItems.value =
-    props.options[parentOrder].children !== undefined
-      ? (props.options[parentOrder].children as UnwrapRef<
-          SearchInputOption<T>[]
-        >)
-      : [];
-};
-
-watch(
-  [
-    scrollItems,
-    () => {
-      return Math.ceil(scrollAmount.value / (ITEM_HEIGHT + DIVIDER_HEIGHT));
-    },
-  ],
-  ([scrollItems, showFrom]) => {
-    const hiddenItems = (() => {
-      if (showFrom === 0) return [];
-      return scrollItems.slice(0, showFrom - 1);
-    })();
-    hiddenItems.forEach((item) => {
-      if (mutableSelectedItem.value.includes(item.value as T)) {
-        const index = mutableSelectedItem.value.indexOf(item.value as T);
-        mutableSelectedItem.value.splice(index, 1);
-      }
-    });
-  }
-);
-
-const isBorder = computed(() => (options: SearchInputOption<T>[]) => {
-  return options.some((option) =>
-    mutableSelectedItem.value.includes(option.value)
-  );
 });
 
 const computedPopupWidth = computed(() => props.popupWidth);
@@ -215,19 +158,9 @@ const computedIconColor = computed(() => (value: T) => {
 });
 
 const onMouseover = (value: T, options?: SearchInputOption<T>[]) => {
-  scrollAmount.value = optionsRef.value?.[0].scrollTop || 0;
   activeItem.value = value;
   if (!options) return;
   activeItemIndex.value = options.findIndex((option) => option.value === value);
-  options.forEach((option: SearchInputOption<T>) => {
-    if (mutableSelectedItem.value.includes(option.value)) {
-      const index = mutableSelectedItem.value.indexOf(option.value);
-      mutableSelectedItem.value.splice(index, 1);
-    }
-  });
-  if (!mutableSelectedItem.value.includes(value)) {
-    mutableSelectedItem.value.push(value);
-  }
 };
 
 const handleClickCheckbox = (value: T) => {

--- a/packages/wiz-ui-next/src/components/base/inputs/search-input/search-popup.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/search-input/search-popup.vue
@@ -116,7 +116,7 @@
   </template>
 </template>
 
-<script setup lang="ts">
+<script setup lang="ts" generic="T">
 import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
 import * as styles from "@wizleap-inc/wiz-ui-styles/bases/search-input.css";
 import { PropType, computed, ref, watch } from "vue";
@@ -139,7 +139,7 @@ defineOptions({
 
 const props = defineProps({
   options: {
-    type: Array as PropType<SearchInputOption[]>,
+    type: Array as PropType<SearchInputOption<T>[]>,
     required: true,
   },
   modelValue: {
@@ -182,7 +182,7 @@ const mutableSelectedItem = computed(() => {
 
 const optionsRef = ref<HTMLElement[]>();
 const scrollAmount = ref<number>(0);
-const scrollItems = ref<SearchInputOption[]>([]);
+const scrollItems = ref<SearchInputOption<T>[]>([]);
 const onScroll = (parentOrder: number) => {
   scrollAmount.value = optionsRef.value?.[0].scrollTop || 0;
   scrollItems.value = props.options[parentOrder].children ?? [];
@@ -209,7 +209,7 @@ watch(
   }
 );
 
-const isBorder = computed(() => (options: SearchInputOption[]) => {
+const isBorder = computed(() => (options: SearchInputOption<T>[]) => {
   return options.some((option) =>
     mutableSelectedItem.value.includes(option.value)
   );
@@ -224,12 +224,12 @@ const computedIconColor = computed(() => (value: number) => {
   return "gray.500";
 });
 
-const onMouseover = (value: number, options?: SearchInputOption[]) => {
+const onMouseover = (value: number, options?: SearchInputOption<T>[]) => {
   scrollAmount.value = optionsRef.value?.[0].scrollTop || 0;
   activeItem.value = value;
   if (!options) return;
   activeItemIndex.value = options.findIndex((option) => option.value === value);
-  options.forEach((option: SearchInputOption) => {
+  options.forEach((option: SearchInputOption<T>) => {
     if (mutableSelectedItem.value.includes(option.value)) {
       const index = mutableSelectedItem.value.indexOf(option.value);
       mutableSelectedItem.value.splice(index, 1);

--- a/packages/wiz-ui-next/src/components/base/inputs/search-input/stories/options.ts
+++ b/packages/wiz-ui-next/src/components/base/inputs/search-input/stories/options.ts
@@ -1,6 +1,6 @@
 import { SearchInputOption } from "../types";
 
-export const defaultOption: SearchInputOption[] = [
+export const defaultOption: SearchInputOption<number>[] = [
   {
     label: "テスト会社1",
     value: 1,
@@ -204,7 +204,7 @@ export const defaultOption: SearchInputOption[] = [
   },
 ];
 
-export const openOption: SearchInputOption[] = [
+export const openOption: SearchInputOption<number>[] = [
   {
     label: "テスト会社1",
     value: 1,
@@ -299,7 +299,7 @@ export const openOption: SearchInputOption[] = [
   },
 ];
 
-export const longLabelOption: SearchInputOption[] = [
+export const longLabelOption: SearchInputOption<number>[] = [
   {
     label: "テスト会社1",
     value: 1,
@@ -324,7 +324,7 @@ export const longLabelOption: SearchInputOption[] = [
   },
 ];
 
-export const expandOption: SearchInputOption[] = [
+export const expandOption: SearchInputOption<number>[] = [
   {
     label: "親要素1",
     value: 1,
@@ -373,7 +373,7 @@ const tag = {
   label: "タグ",
 };
 
-export const taggedOptions: SearchInputOption[] = [
+export const taggedOptions: SearchInputOption<number>[] = [
   {
     label: "テスト会社1",
     value: 1,
@@ -459,7 +459,7 @@ export const taggedOptions: SearchInputOption[] = [
   },
 ];
 
-export const simpleOption: SearchInputOption[] = [
+export const simpleOption: SearchInputOption<number>[] = [
   {
     label: "選択肢1",
     value: 1,
@@ -484,8 +484,8 @@ const getNextValue = (): number => {
 const generateGrandchildren = (
   startValue: number,
   count: number
-): SearchInputOption[] => {
-  const grandchildren: SearchInputOption[] = [];
+): SearchInputOption<number>[] => {
+  const grandchildren: SearchInputOption<number>[] = [];
   for (let i = 0; i < count; i++) {
     const grandchildValue = getNextValue();
     grandchildren.push({
@@ -500,8 +500,8 @@ const generateGrandchildren = (
 const generateChildren = (
   startValue: number,
   count: number
-): SearchInputOption[] => {
-  const children: SearchInputOption[] = [];
+): SearchInputOption<number>[] => {
+  const children: SearchInputOption<number>[] = [];
   for (let i = 0; i < count; i++) {
     const childValue = getNextValue();
     children.push({
@@ -520,8 +520,8 @@ const generateChildren = (
 const generateParentElements = (
   startValue: number,
   count: number
-): SearchInputOption[] => {
-  const parentElements: SearchInputOption[] = [];
+): SearchInputOption<number>[] => {
+  const parentElements: SearchInputOption<number>[] = [];
   for (let i = 0; i < count; i++) {
     const parentValue = getNextValue();
     parentElements.push({
@@ -533,7 +533,7 @@ const generateParentElements = (
   return parentElements;
 };
 
-export const debugOption: SearchInputOption[] = [
+export const debugOption: SearchInputOption<number>[] = [
   {
     label: "親要素1",
     value: getNextValue(),
@@ -552,7 +552,7 @@ export const debugOption: SearchInputOption[] = [
   ...generateParentElements(getNextValue(), 13),
 ];
 
-export const emptyMessageOptions: SearchInputOption[] = [
+export const emptyMessageOptions: SearchInputOption<number>[] = [
   {
     label: "テスト会社1",
     value: 1,

--- a/packages/wiz-ui-next/src/components/base/inputs/search-input/stories/search-input.stories.ts
+++ b/packages/wiz-ui-next/src/components/base/inputs/search-input/stories/search-input.stories.ts
@@ -8,11 +8,11 @@ import WizSearchInput from "../search-input.vue";
 import {
   debugOption,
   defaultOption,
+  emptyMessageOptions,
   expandOption,
   longLabelOption,
   openOption,
   simpleOption,
-  emptyMessageOptions,
   taggedOptions,
 } from "./options";
 

--- a/packages/wiz-ui-next/src/components/base/inputs/search-input/types.ts
+++ b/packages/wiz-ui-next/src/components/base/inputs/search-input/types.ts
@@ -2,9 +2,9 @@ export type Tag = {
   label: string;
 };
 
-export type SearchInputOption = {
+export type SearchInputOption<T> = {
   label: string;
   value: number;
-  children?: SearchInputOption[];
+  children?: SearchInputOption<T>[];
   tag?: Tag;
 };

--- a/packages/wiz-ui-next/src/components/base/inputs/search-input/types.ts
+++ b/packages/wiz-ui-next/src/components/base/inputs/search-input/types.ts
@@ -1,10 +1,12 @@
+export type CheckboxOption = string | number | string[]; // WizCheckBoxNew
+
 export type Tag = {
   label: string;
 };
 
-export type SearchInputOption<T> = {
+export type SearchInputOption<T extends CheckboxOption> = {
   label: string;
-  value: number;
+  value: T;
   children?: SearchInputOption<T>[];
   tag?: Tag;
 };

--- a/packages/wiz-ui-next/src/components/base/inputs/search-selector/search-selector.stories.ts
+++ b/packages/wiz-ui-next/src/components/base/inputs/search-selector/search-selector.stories.ts
@@ -55,7 +55,7 @@ v-modelには選択中のアイテムを渡します。
 } as Meta<typeof WizSearchSelector>;
 
 const _getDummyOptions = (label: string, count: number, exLabel?: string) => {
-  const options: SelectBoxOption[] = [];
+  const options: SelectBoxOption<number>[] = [];
   for (let i = 1; i <= count; i++) {
     options.push({ label: label + i, value: i, exLabel: exLabel });
     options.push({ label: label + i * 10, value: i * 10, exLabel: exLabel });
@@ -67,7 +67,7 @@ const Template =
   (
     initValue: number[],
     open: boolean,
-    initOptions: SelectBoxOption[],
+    initOptions: SelectBoxOption<number>[],
     initSearchValue: string
   ): StoryFn<typeof WizSearchSelector> =>
   (args) => ({
@@ -76,7 +76,8 @@ const Template =
       const currentValue = ref(initValue);
       const isOpen = ref(open);
       const searchValue = ref(initSearchValue);
-      const options = ref<SelectBoxOption[]>(initOptions);
+      const options = ref<SelectBoxOption<number>[]>(initOptions);
+
       const emits = {
         select: (n: number) => {
           currentValue.value.push(n);
@@ -98,7 +99,14 @@ const Template =
           currentValue.value.push(options.value.length);
         },
       };
-      return { args, currentValue, options, searchValue, isOpen, emits };
+      return {
+        args,
+        currentValue,
+        options,
+        searchValue,
+        isOpen,
+        emits,
+      };
     },
     template: `
     <WizHStack>
@@ -108,6 +116,7 @@ const Template =
         :options="options"
         :isOpen="isOpen"
         :searchValue="searchValue"
+        :valueToOption="value2Option"
         @toggle="emits.toggle"
         @update:modelValue="emits.select"
         @unselect="emits.unselect"
@@ -121,7 +130,7 @@ const Template =
 const code = (
   initValue: number[],
   open: boolean,
-  initOptions: SelectBoxOption[],
+  initOptions: SelectBoxOption<number>[],
   initSearchValue: string,
   opts?: {
     disabled?: boolean;

--- a/packages/wiz-ui-next/src/components/base/inputs/search-selector/types.ts
+++ b/packages/wiz-ui-next/src/components/base/inputs/search-selector/types.ts
@@ -1,5 +1,5 @@
-export interface SelectBoxOption {
+export interface SelectBoxOption<T> {
   label: string;
-  value: number;
+  value?: T;
   exLabel?: string;
 }

--- a/packages/wiz-ui-next/src/components/base/inputs/selectbox/selectbox.stories.ts
+++ b/packages/wiz-ui-next/src/components/base/inputs/selectbox/selectbox.stories.ts
@@ -37,7 +37,7 @@ export default {
 const Template: StoryFn<typeof WizSelectBox> = (args) => ({
   components: { WizSelectBox, WizHStack },
   setup() {
-    const value = ref(args.value);
+    const value = ref(args.modelValue);
     return { value, args };
   },
   template: `
@@ -48,7 +48,7 @@ const Template: StoryFn<typeof WizSelectBox> = (args) => ({
 });
 
 const _getDummyOptions = (label: string, count: number, exLabel?: string) => {
-  const options: SelectBoxOption[] = [];
+  const options: SelectBoxOption<number>[] = [];
   for (let i = 1; i <= count; i++) {
     options.push({ label: label + i, value: i, exLabel });
   }
@@ -95,7 +95,7 @@ export const WithExtraLabel = Template.bind({});
 WithExtraLabel.args = {
   options: _getDummyOptions("test", 3, "(10)"),
   isOpen: true,
-  value: 1,
+  modelValue: 1,
 };
 
 export const ExtraLabel = Template.bind({});
@@ -103,7 +103,7 @@ ExtraLabel.args = {
   options: _getDummyOptions("test", 3, "(10)"),
   isOpen: true,
   showExLabel: true,
-  value: 1,
+  modelValue: 1,
 };
 
 export const IsDirectionFixed = Template.bind({});

--- a/packages/wiz-ui-next/src/components/base/inputs/selectbox/selectbox.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/selectbox/selectbox.vue
@@ -65,7 +65,7 @@
   </WizPopupContainer>
 </template>
 
-<script setup lang="ts">
+<script setup lang="ts" generic="T">
 import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
 import {
   selectBoxCursorStyle,
@@ -80,7 +80,7 @@ import {
   selectBoxStyle,
 } from "@wizleap-inc/wiz-ui-styles/bases/selectbox-input.css";
 import { inputBorderStyle } from "@wizleap-inc/wiz-ui-styles/commons";
-import { PropType, computed, inject, ref } from "vue";
+import { computed, inject, ref } from "vue";
 
 import { WizPopup, WizPopupContainer } from "@/components";
 import { WizIExpandLess, WizIExpandMore } from "@/components/icons";
@@ -94,53 +94,27 @@ defineOptions({
   name: ComponentName.SelectBox,
 });
 
-const props = defineProps({
-  options: {
-    type: Array as PropType<SelectBoxOption[]>,
-    required: true,
-  },
-  modelValue: {
-    type: Number,
-    required: true,
-  },
-  placeholder: {
-    type: String,
-    required: false,
-    default: "選択してください",
-  },
-  width: {
-    type: String,
-    required: false,
-    default: "10rem",
-  },
-  disabled: {
-    type: Boolean,
-    required: false,
-    default: false,
-  },
-  expand: {
-    type: Boolean,
-    required: false,
-  },
-  isOpen: {
-    type: Boolean,
-    required: false,
-    default: false,
-  },
-  isDirectionFixed: {
-    type: Boolean,
-    required: false,
-    default: false,
-  },
-  showExLabel: {
-    type: Boolean,
-    required: false,
-    default: false,
-  },
-  dropdownMaxHeight: {
-    type: String,
-    required: false,
-  },
+type Props<T> = {
+  options: SelectBoxOption<T>[];
+  modelValue: T;
+  placeholder?: string;
+  width?: string;
+  disabled?: boolean;
+  expand?: boolean;
+  isOpen?: boolean;
+  isDirectionFixed?: boolean;
+  showExLabel?: boolean;
+  dropdownMaxHeight?: string;
+};
+
+const props = withDefaults(defineProps<Props<T>>(), {
+  placeholder: "選択してください",
+  width: "10rem",
+  disabled: false,
+  expand: false,
+  isOpen: false,
+  isDirectionFixed: false,
+  showExLabel: false,
 });
 
 const openSelectBox = ref(props.isOpen);
@@ -151,12 +125,9 @@ const toggleSelectBox = () => {
   openSelectBox.value = !openSelectBox.value;
 };
 
-interface Emit {
-  (e: "update:modelValue", value: number): void;
-}
-const emit = defineEmits<Emit>();
+const emit = defineEmits<{ "update:modelValue": [value: T] }>();
 
-const onSelect = (value: number) => {
+const onSelect = (value: T) => {
   toggleSelectBox();
   emit("update:modelValue", value);
 };

--- a/packages/wiz-ui-next/src/components/base/inputs/selectbox/types.ts
+++ b/packages/wiz-ui-next/src/components/base/inputs/selectbox/types.ts
@@ -1,5 +1,5 @@
-export interface SelectBoxOption {
+export interface SelectBoxOption<T> {
   label: string;
   exLabel?: string;
-  value: number;
+  value: T;
 }

--- a/packages/wiz-ui-next/src/components/base/navigation/container.stories.ts
+++ b/packages/wiz-ui-next/src/components/base/navigation/container.stories.ts
@@ -214,7 +214,7 @@ export const Fixed: StoryFn = (_, { argTypes }) => ({
 const createButton = (
   n: number,
   click: (n: number) => void
-): ButtonGroupItem => ({
+): ButtonGroupItem<number> => ({
   kind: "button",
   option: {
     label: `label ${n}`,

--- a/packages/wiz-ui-next/src/components/base/navigation/item.vue
+++ b/packages/wiz-ui-next/src/components/base/navigation/item.vue
@@ -69,23 +69,23 @@
 <script setup lang="ts">
 import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
 import {
-  navigationItemStyle,
   navigationItemActiveStyle,
-  navigationItemIconStyle,
-  navigationItemIconActiveStyle,
-  navigationItemTextStyle,
-  navigationItemTextActiveStyle,
   navigationItemDisabledStyle,
+  navigationItemIconActiveStyle,
   navigationItemIconDisabledStyle,
+  navigationItemIconStyle,
+  navigationItemStyle,
+  navigationItemTextActiveStyle,
+  navigationItemTextStyle,
   navigationPopupContainerStyle,
 } from "@wizleap-inc/wiz-ui-styles/bases/navigation.css";
-import { computed, PropType, ref } from "vue";
+import { PropType, computed, ref } from "vue";
 import { RouterLinkProps } from "vue-router";
 
 import {
-  WizPopupContainer,
   WizPopup,
   WizPopupButtonGroup,
+  WizPopupContainer,
   WizTooltip,
 } from "@/components";
 import type { TIcon } from "@/components/icons";
@@ -129,7 +129,7 @@ const props = defineProps({
     default: true,
   },
   buttons: {
-    type: Array as PropType<ButtonGroupItem[]>,
+    type: Array as PropType<ButtonGroupItem<number>[]>,
     required: false,
   },
   isOpen: {

--- a/packages/wiz-ui-next/src/components/base/navigation/item.vue
+++ b/packages/wiz-ui-next/src/components/base/navigation/item.vue
@@ -66,7 +66,7 @@
   </WizTooltip>
 </template>
 
-<script setup lang="ts">
+<script setup lang="ts" generic="T">
 import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
 import {
   navigationItemActiveStyle,
@@ -129,7 +129,7 @@ const props = defineProps({
     default: true,
   },
   buttons: {
-    type: Array as PropType<ButtonGroupItem<number>[]>,
+    type: Array as PropType<ButtonGroupItem<T>[]>,
     required: false,
   },
   isOpen: {

--- a/packages/wiz-ui-next/src/components/base/navigation/item.vue
+++ b/packages/wiz-ui-next/src/components/base/navigation/item.vue
@@ -79,7 +79,7 @@ import {
   navigationItemTextStyle,
   navigationPopupContainerStyle,
 } from "@wizleap-inc/wiz-ui-styles/bases/navigation.css";
-import { PropType, computed, ref } from "vue";
+import { computed, ref } from "vue";
 import { RouterLinkProps } from "vue-router";
 
 import {
@@ -96,46 +96,22 @@ defineOptions({
   name: ComponentName.NavigationItem,
 });
 
-const props = defineProps({
-  icon: {
-    type: Object as PropType<TIcon>,
-    required: true,
-  },
-  label: {
-    type: String,
-    required: true,
-  },
-  active: {
-    type: Boolean,
-    required: true,
-  },
-  to: {
-    type: [Object, String] as PropType<RouterLinkProps["to"]>,
-    required: true,
-  },
-  disabled: {
-    type: Boolean,
-    required: false,
-    default: false,
-  },
-  tooltipText: {
-    type: String,
-    required: false,
-    default: null,
-  },
-  lockingPopup: {
-    type: Boolean,
-    required: false,
-    default: true,
-  },
-  buttons: {
-    type: Array as PropType<ButtonGroupItem<T>[]>,
-    required: false,
-  },
-  isOpen: {
-    type: Boolean,
-    required: false,
-  },
+type Props<T> = {
+  icon: TIcon;
+  label: string;
+  active: boolean;
+  to: RouterLinkProps["to"];
+  disabled?: boolean;
+  tooltipText?: string;
+  lockingPopup?: boolean;
+  buttons?: ButtonGroupItem<T>[];
+  isOpen?: boolean;
+};
+
+const props = withDefaults(defineProps<Props<T>>(), {
+  disabled: false,
+  lockingPopup: true,
+  isOpen: false,
 });
 
 const isExternalLink = computed(

--- a/packages/wiz-ui-next/src/components/base/navigation/item.vue
+++ b/packages/wiz-ui-next/src/components/base/navigation/item.vue
@@ -102,7 +102,7 @@ type Props<T> = {
   active: boolean;
   to: RouterLinkProps["to"];
   disabled?: boolean;
-  tooltipText?: string;
+  tooltipText?: string | null;
   lockingPopup?: boolean;
   buttons?: ButtonGroupItem<T>[];
   isOpen?: boolean;
@@ -112,6 +112,7 @@ const props = withDefaults(defineProps<Props<T>>(), {
   disabled: false,
   lockingPopup: true,
   isOpen: false,
+  tooltipText: null,
 });
 
 const isExternalLink = computed(

--- a/packages/wiz-ui-next/src/components/base/popup-button-group/popup-button-group.stories.ts
+++ b/packages/wiz-ui-next/src/components/base/popup-button-group/popup-button-group.stories.ts
@@ -3,15 +3,15 @@ import { SPACING_ACCESSORS } from "@wizleap-inc/wiz-ui-constants";
 import { ref } from "vue";
 
 import {
-  WizPopupContainer,
-  WizPopup,
-  WizIOpenInNew,
-  WizIAddCircle,
-  WizPopupButtonGroup,
   TIcon,
+  WizIAddCircle,
+  WizIOpenInNew,
+  WizPopup,
+  WizPopupButtonGroup,
+  WizPopupContainer,
 } from "@/components";
 
-import { PopupButtonOption, ButtonGroupItem } from "./types";
+import { ButtonGroupItem, PopupButtonOption } from "./types";
 
 export default {
   title: "Base/PopupButtonGroup",
@@ -49,7 +49,7 @@ const _getDummyOptions = (
   click: (n: number) => void,
   exLabel?: string
 ) => {
-  const options: PopupButtonOption[] = [];
+  const options: PopupButtonOption<number>[] = [];
   const createIcon = (i: number) => {
     if (i % 3 === 0) {
       return undefined;
@@ -74,7 +74,7 @@ const _getDummyOptions = (
     });
   });
   return options.map(
-    (opt) => ({ kind: "button", option: opt } as ButtonGroupItem)
+    (opt) => ({ kind: "button", option: opt } as ButtonGroupItem<number>)
   );
 };
 
@@ -83,7 +83,7 @@ const createButton = (
   click: (n: number) => void,
   disabled?: boolean,
   icon?: TIcon
-): ButtonGroupItem => ({
+): ButtonGroupItem<number> => ({
   kind: "button",
   option: {
     label: `item ${n}`,
@@ -95,7 +95,9 @@ const createButton = (
   },
 });
 
-const _getDummyItems = (click: (arg: number) => void): ButtonGroupItem[] => [
+const _getDummyItems = (
+  click: (arg: number) => void
+): ButtonGroupItem<number>[] => [
   {
     kind: "group",
     title: "タイトル1",
@@ -136,7 +138,9 @@ Disabled.args = {
 export const DisabledButton: StoryFn<typeof WizPopupButtonGroup> = (args) => ({
   components: { WizPopupButtonGroup },
   setup() {
-    const createOptions = (click: (arg: number) => void): ButtonGroupItem[] => [
+    const createOptions = (
+      click: (arg: number) => void
+    ): ButtonGroupItem<number>[] => [
       createButton(1, click, true, WizIOpenInNew),
       createButton(2, click, false, WizIOpenInNew),
       createButton(3, click, true),
@@ -177,7 +181,9 @@ Popup.args = {
 export const Divider: StoryFn<typeof WizPopupButtonGroup> = (args) => ({
   components: { WizPopupButtonGroup },
   setup() {
-    const createOptions = (click: (arg: number) => void): ButtonGroupItem[] => [
+    const createOptions = (
+      click: (arg: number) => void
+    ): ButtonGroupItem<number>[] => [
       createButton(1, click),
       createButton(2, click),
       { kind: "divider" },

--- a/packages/wiz-ui-next/src/components/base/popup-button-group/popup-button-group.vue
+++ b/packages/wiz-ui-next/src/components/base/popup-button-group/popup-button-group.vue
@@ -82,24 +82,24 @@
   </WizVStack>
 </template>
 
-<script setup lang="ts">
+<script setup lang="ts" generic="T">
 import {
   ComponentName,
   SpacingKeys,
   THEME,
 } from "@wizleap-inc/wiz-ui-constants";
 import {
-  popupButtonGroupStyle,
-  popupButtonGroupDisabledCursorStyle,
+  borderRadiusStyle,
   popupButtonGroupButtonBaseStyle,
-  popupButtonGroupTitleBaseStyle,
+  popupButtonGroupButtonVariantStyle,
+  popupButtonGroupDisabledCursorStyle,
   popupButtonGroupDividerStyle,
   popupButtonGroupInnerContainerStyle,
+  popupButtonGroupStyle,
+  popupButtonGroupTitleBaseStyle,
   popupButtonGroupTitleVariantStyle,
-  popupButtonGroupButtonVariantStyle,
-  borderRadiusStyle,
 } from "@wizleap-inc/wiz-ui-styles/bases/popup-button-group.css";
-import { computed, PropType, ref } from "vue";
+import { PropType, UnwrapRef, computed, ref } from "vue";
 
 import { WizIcon, WizPopupButtonGroup, WizVStack } from "@/components";
 
@@ -111,7 +111,7 @@ defineOptions({
 
 const props = defineProps({
   options: {
-    type: Array as PropType<ButtonGroupItem[]>,
+    type: Array as PropType<ButtonGroupItem<T>[]>,
     required: true,
   },
   width: {
@@ -157,7 +157,10 @@ const props = defineProps({
 
 type ItemElement =
   | { kind: "divider" }
-  | { kind: "item"; item: Exclude<ButtonGroupItem, { kind: "divider" }> };
+  | {
+      kind: "item";
+      item: Exclude<ButtonGroupItem<T>, { kind: "divider" }>;
+    };
 
 const items = computed(() => {
   const divider: ItemElement = { kind: "divider" };
@@ -189,13 +192,15 @@ const items = computed(() => {
   return items;
 });
 
-const isClicking = ref<number | null>(null);
-const isHover = ref<number | null>(null);
+const isClicking = ref<T | null>(null);
+const isHover = ref<T | null>(null);
 
-const onHoldClick = (item: ButtonGroupItem) => {
+const onHoldClick = (item: ButtonGroupItem<T>) => {
   if (props.disabled) return;
   if (item.kind === "button" && !item.option.disabled) {
-    isClicking.value = item.option.value;
+    isClicking.value = item.option.value
+      ? (item.option.value as UnwrapRef<T>)
+      : null;
     const mouseup = () => {
       isClicking.value = null;
       document.removeEventListener("mouseup", mouseup);
@@ -204,28 +209,30 @@ const onHoldClick = (item: ButtonGroupItem) => {
   }
 };
 
-const popupButtonMouseDown = (item: ButtonGroupItem) => {
+const popupButtonMouseDown = (item: ButtonGroupItem<T>) => {
   if (props.disabled) return;
   if (item.kind === "button" && !item.option.disabled) {
     item.option.onClick();
   }
 };
 
-const popupButtonMouseOver = (item: ButtonGroupItem) => {
+const popupButtonMouseOver = (item: ButtonGroupItem<T>) => {
   if (props.disabled) return;
   if (item.kind === "button" && !item.option.disabled) {
-    isHover.value = item.option.value;
+    isHover.value = item.option.value
+      ? (item.option.value as UnwrapRef<T>)
+      : null;
   }
 };
 
-const popupButtonMouseOut = (item: ButtonGroupItem) => {
+const popupButtonMouseOut = (item: ButtonGroupItem<T>) => {
   if (props.disabled) return;
   if (item.kind === "button" && !item.option.disabled) {
     isHover.value = null;
   }
 };
 
-const popupButtonKeyPressEnter = (item: ButtonGroupItem) => {
+const popupButtonKeyPressEnter = (item: ButtonGroupItem<T>) => {
   if (props.disabled) return;
   if (item.kind === "button" && !item.option.disabled) {
     item.option.onClick();

--- a/packages/wiz-ui-next/src/components/base/popup-button-group/popup-button-group.vue
+++ b/packages/wiz-ui-next/src/components/base/popup-button-group/popup-button-group.vue
@@ -99,7 +99,7 @@ import {
   popupButtonGroupTitleBaseStyle,
   popupButtonGroupTitleVariantStyle,
 } from "@wizleap-inc/wiz-ui-styles/bases/popup-button-group.css";
-import { PropType, UnwrapRef, computed, ref } from "vue";
+import { UnwrapRef, computed, ref } from "vue";
 
 import { WizIcon, WizPopupButtonGroup, WizVStack } from "@/components";
 
@@ -109,50 +109,27 @@ defineOptions({
   name: ComponentName.PopupButtonGroup,
 });
 
-const props = defineProps({
-  options: {
-    type: Array as PropType<ButtonGroupItem<T>[]>,
-    required: true,
-  },
-  width: {
-    type: String,
-    required: false,
-    default: "10rem",
-  },
-  p: {
-    type: String as PropType<SpacingKeys>,
-    required: false,
-    default: "no",
-  },
-  borderRadius: {
-    type: String as PropType<SpacingKeys>,
-    required: false,
-    default: "no",
-  },
-  disabled: {
-    type: Boolean,
-    required: false,
-    default: false,
-  },
-  expand: {
-    type: Boolean,
-    required: false,
-  },
-  groupDivider: {
-    type: Boolean,
-    required: false,
-    default: false,
-  },
-  buttonDivider: {
-    type: Boolean,
-    required: false,
-    default: false,
-  },
-  depth: {
-    type: Number,
-    required: false,
-    default: 0,
-  },
+type Props<T> = {
+  options: ButtonGroupItem<T>[];
+  width?: string;
+  p?: SpacingKeys;
+  borderRadius?: SpacingKeys;
+  disabled?: boolean;
+  expand?: boolean;
+  groupDivider?: boolean;
+  buttonDivider?: boolean;
+  depth?: number;
+};
+
+const props = withDefaults(defineProps<Props<T>>(), {
+  width: "10rem",
+  p: "no",
+  borderRadius: "no",
+  disabled: false,
+  expand: false,
+  groupDivider: false,
+  buttonDivider: false,
+  depth: 0,
 });
 
 type ItemElement =

--- a/packages/wiz-ui-next/src/components/base/popup-button-group/types.ts
+++ b/packages/wiz-ui-next/src/components/base/popup-button-group/types.ts
@@ -1,7 +1,7 @@
 import { TIcon } from "@/components";
-export interface PopupButtonOption {
+export interface PopupButtonOption<T> {
   label: string;
-  value: number;
+  value?: T;
   exLabel?: string;
   icon?: TIcon;
   iconDefaultColor?: "green.800" | "gray.500";
@@ -9,13 +9,13 @@ export interface PopupButtonOption {
   onClick: () => void;
 }
 
-export type ButtonGroupItem =
-  | { kind: "button"; option: PopupButtonOption }
+export type ButtonGroupItem<T> =
+  | { kind: "button"; option: PopupButtonOption<T> }
   | { kind: "divider" }
   | {
       kind: "group";
       title: string;
-      items: ButtonGroupItem[];
+      items: ButtonGroupItem<T>[];
       groupDivider?: boolean;
       buttonDivider?: boolean;
     };

--- a/packages/wiz-ui-next/src/components/custom/chat/card/chat-card.stories.ts
+++ b/packages/wiz-ui-next/src/components/custom/chat/card/chat-card.stories.ts
@@ -155,7 +155,7 @@ SomeonesTyping.args = {
   isOpen: true,
   typingUsername: "なんとかかんとか",
 };
-const STATUS_OPTIONS: SelectBoxOption[] = [
+const STATUS_OPTIONS: SelectBoxOption<number>[] = [
   {
     label: "ステータス１",
     value: 1,

--- a/packages/wiz-ui-next/src/components/custom/chat/card/chat-card.vue
+++ b/packages/wiz-ui-next/src/components/custom/chat/card/chat-card.vue
@@ -97,7 +97,7 @@
   </WizBox>
 </template>
 
-<script setup lang="ts">
+<script setup lang="ts" generic="T">
 import {
   ARIA_LABELS,
   ComponentName,
@@ -105,7 +105,7 @@ import {
 } from "@wizleap-inc/wiz-ui-constants";
 import { chatCardOpenButtonStyle } from "@wizleap-inc/wiz-ui-styles/customs/chat-card.css";
 import { formatDateToMonthDayWeek } from "@wizleap-inc/wiz-ui-utils";
-import { PropType, computed, nextTick, onMounted, ref, watch } from "vue";
+import { computed, nextTick, onMounted, ref, watch } from "vue";
 
 import {
   WizBox,
@@ -130,62 +130,30 @@ defineOptions({
   name: ComponentName.ChatCard,
 });
 
-const props = defineProps({
-  modelValue: {
-    type: String,
-    required: true,
-  },
-  username: {
-    type: String,
-    required: true,
-  },
-  placeholder: {
-    type: String,
-    required: false,
-  },
-  messages: {
-    type: Array as PropType<Message[]>,
-    required: true,
-  },
-  isOpen: {
-    type: Boolean,
-    required: false,
-    default: false,
-  },
-  haveNewMessage: {
-    type: Boolean,
-    required: false,
-  },
-  formRows: {
-    type: Number,
-    required: false,
-  },
-  typingUsername: {
-    type: String,
-    required: false,
-  },
-  status: {
-    type: Number,
-    required: false,
-  },
-  statusOptions: {
-    type: Array as PropType<SelectBoxOption[]>,
-    required: false,
-  },
-  statusPlaceholder: {
-    type: String,
-    required: false,
-  },
+type Props<T> = {
+  modelValue: string;
+  username: string;
+  placeholder?: string;
+  messages: Message[];
+  isOpen?: boolean;
+  haveNewMessage?: boolean;
+  formRows?: number;
+  typingUsername?: string;
+  status?: T;
+  statusOptions?: SelectBoxOption<T>[];
+  statusPlaceholder?: string;
+};
+
+const props = withDefaults(defineProps<Props<T>>(), {
+  placeholder: "",
+  isOpen: false,
 });
-
-interface Emit {
-  (e: "update:modelValue", value: string): void;
-  (e: "submit"): void;
-  (e: "toggleDisplay"): void;
-  (e: "update:status", value: number): void;
-}
-
-const emits = defineEmits<Emit>();
+const emits = defineEmits<{
+  "update:modelValue": [value: string];
+  submit: [];
+  toggleDisplay: [];
+  "update:status": [value: T];
+}>();
 
 const canAnimate = ref(false);
 
@@ -246,7 +214,7 @@ const textValue = computed({
 });
 
 const statusValue = computed({
-  get: () => props.status || NaN,
+  get: () => props.status,
   set: (value) => value && emits("update:status", value),
 });
 

--- a/packages/wiz-ui-next/src/components/custom/form/group.stories.ts
+++ b/packages/wiz-ui-next/src/components/custom/form/group.stories.ts
@@ -9,14 +9,14 @@ import {
 import { ref } from "vue";
 
 import {
-  WizDateRangePicker,
-  WizTextInput,
-  WizPasswordInput,
-  WizSelectBox,
   WizCheckBox,
-  WizRadio,
-  WizTextArea,
   WizDatePicker,
+  WizDateRangePicker,
+  WizPasswordInput,
+  WizRadio,
+  WizSelectBox,
+  WizTextArea,
+  WizTextInput,
   WizTimePicker,
 } from "@/components";
 import { CheckBoxOption } from "@/components/base/inputs/checkbox/types";
@@ -27,7 +27,7 @@ import {
 import { RadioOption } from "@/components/base/inputs/radio/types";
 import { SelectBoxOption } from "@/components/base/inputs/selectbox/types";
 
-import { WizFormGroup, WizFormControl } from ".";
+import { WizFormControl, WizFormGroup } from ".";
 
 export default {
   title: "Custom/Form/Group",
@@ -187,7 +187,7 @@ LabelFontSize.parameters = {
   },
 };
 
-const SELECT_BOX_CHOICES: SelectBoxOption[] = [
+const SELECT_BOX_CHOICES: SelectBoxOption<number>[] = [
   {
     label: "選択肢1",
     value: 1,
@@ -216,7 +216,7 @@ export const AllInput: StoryFn<typeof WizFormControl> = () => ({
     const textInput = ref("");
     const passwordInput = ref("");
     const textareaInput = ref("");
-    const SELECT_OPTIONS: SelectBoxOption[] = SELECT_BOX_CHOICES;
+    const SELECT_OPTIONS: SelectBoxOption<number>[] = SELECT_BOX_CHOICES;
     const selectInput = ref<string | null>(null);
     const checkBoxOptions: CheckBoxOption[] = [
       {
@@ -324,7 +324,7 @@ export const AllInputError: StoryFn<typeof WizFormControl> = () => ({
     const textInput = ref("");
     const passwordInput = ref("");
     const textareaInput = ref("");
-    const SELECT_OPTIONS: SelectBoxOption[] = SELECT_BOX_CHOICES;
+    const SELECT_OPTIONS: SelectBoxOption<number>[] = SELECT_BOX_CHOICES;
     const selectInput = ref(0);
     const checkBoxOptions: CheckBoxOption[] = [
       {

--- a/packages/wiz-ui-next/src/components/custom/timeline/stories/timeline-item.stories.ts
+++ b/packages/wiz-ui-next/src/components/custom/timeline/stories/timeline-item.stories.ts
@@ -279,7 +279,7 @@ MobileDevice.args = {
 MobileDevice.decorators = [
   () => ({
     setup() {
-      const device = ref("mobile");
+      const device = ref<"mobile" | "pc">("mobile");
       provide(TIMELINE_KEY, { device });
     },
     template: `<story />`,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,18 +168,18 @@ importers:
         specifier: 'workspace:'
         version: link:../../packages/utils
       vue:
-        specifier: ^3.2.45
-        version: 3.2.47
+        specifier: ^3.4.21
+        version: 3.4.21(typescript@5.2.2)
     devDependencies:
       '@vitejs/plugin-vue':
-        specifier: ^3.2.0
-        version: 3.2.0(vite@3.2.7)(vue@3.2.47)
+        specifier: ^4.1.0
+        version: 4.1.0(vite@4.4.10)(vue@3.4.21)
       vue-router:
         specifier: ^4.1.6
-        version: 4.1.6(vue@3.2.47)
+        version: 4.3.0(vue@3.4.21)
       vue-tsc:
-        specifier: ^1.0.9
-        version: 1.2.0(typescript@5.2.2)
+        specifier: ^2.0.7
+        version: 2.0.7(typescript@5.2.2)
 
   packages/constants: {}
 
@@ -222,27 +222,27 @@ importers:
         specifier: workspace:*
         version: link:../utils
       vue:
-        specifier: ^3.2.45
-        version: 3.2.47
+        specifier: ^3.4.21
+        version: 3.4.21(typescript@5.2.2)
       vue-router:
         specifier: ^4.1.6
-        version: 4.1.6(vue@3.2.47)
+        version: 4.3.0(vue@3.4.21)
     devDependencies:
       '@storybook/vue3':
         specifier: ^7.0.2
-        version: 7.0.2(vue@3.2.47)
+        version: 7.0.2(vue@3.4.21)
       '@storybook/vue3-vite':
         specifier: ^7.0.2
-        version: 7.0.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(vite@4.4.10)(vue@3.2.47)
+        version: 7.0.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(vite@4.4.10)(vue@3.4.21)
       '@vitejs/plugin-vue':
         specifier: ^4.1.0
-        version: 4.1.0(vite@4.4.10)(vue@3.2.47)
+        version: 4.1.0(vite@4.4.10)(vue@3.4.21)
       unplugin-vue-define-options:
         specifier: ^1.1.1
-        version: 1.3.2(vue@3.2.47)
+        version: 1.3.2(vue@3.4.21)
       vue-tsc:
-        specifier: ^1.0.9
-        version: 1.2.0(typescript@5.2.2)
+        specifier: ^2.0.7
+        version: 2.0.7(typescript@5.2.2)
 
   packages/wiz-ui-react:
     dependencies:
@@ -355,10 +355,10 @@ packages:
       '@babel/generator': 7.21.3
       '@babel/helper-module-transforms': 7.21.2
       '@babel/helpers': 7.21.0
-      '@babel/parser': 7.23.0
+      '@babel/parser': 7.24.1
       '@babel/template': 7.20.7
       '@babel/traverse': 7.21.3
-      '@babel/types': 7.21.3
+      '@babel/types': 7.23.0
       convert-source-map: 1.9.0
       debug: 4.3.4
       gensync: 1.0.0-beta.2
@@ -647,7 +647,7 @@ packages:
     resolution: {integrity: sha512-eyAYAsQmB80jNfg4baAtLeWAQHfHFiR483rzFK+BhETlGZaQC9bsfrugfXDCbRHLQbIA7U5NxhhOxN7p/dWIcg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.3
+      '@babel/types': 7.23.0
     dev: true
 
   /@babel/helper-function-name@7.21.0:
@@ -864,20 +864,20 @@ packages:
   /@babel/helper-string-parser@7.19.4:
     resolution: {integrity: sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==}
     engines: {node: '>=6.9.0'}
+    dev: true
 
   /@babel/helper-string-parser@7.22.5:
     resolution: {integrity: sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/helper-validator-identifier@7.19.1:
     resolution: {integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==}
     engines: {node: '>=6.9.0'}
+    dev: true
 
   /@babel/helper-validator-identifier@7.22.20:
     resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/helper-validator-option@7.21.0:
     resolution: {integrity: sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ==}
@@ -896,7 +896,7 @@ packages:
       '@babel/helper-function-name': 7.21.0
       '@babel/template': 7.20.7
       '@babel/traverse': 7.21.3
-      '@babel/types': 7.21.3
+      '@babel/types': 7.23.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -956,6 +956,7 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.21.4
+    dev: true
 
   /@babel/parser@7.21.9:
     resolution: {integrity: sha512-q5PNg/Bi1OpGgx5jYlvWZwAorZepEudDMCLtj967aeS7WMont7dUZI46M2XwcIQqvUlMxWfdLFu4S/qSxeUu5g==}
@@ -972,6 +973,13 @@ packages:
     dependencies:
       '@babel/types': 7.23.0
     dev: true
+
+  /@babel/parser@7.24.1:
+    resolution: {integrity: sha512-Zo9c7N3xdOIQrNip7Lc9wvRPzlRtovHVE4lkz8WEDr7uYh/GMQhSiIgFxGIArRHYdJE5kxtZjAf8rT0xhdLCzg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.23.0
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.18.6(@babel/core@7.21.3):
     resolution: {integrity: sha512-Dgxsyg54Fx1d4Nge8UnvTrED63vrwOdPmyvPzlNN/boaliRP54pm3pGzZD1SJUwrBA+Cs/xdG8kXX6Mn/RfISQ==}
@@ -3163,6 +3171,7 @@ packages:
       '@babel/helper-string-parser': 7.19.4
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
+    dev: true
 
   /@babel/types@7.21.5:
     resolution: {integrity: sha512-m4AfNvVF2mVC/F7fDEdH2El3HzUg9It/XsCxZiOTTA3m3qYfcSVSbTfM6Q9xG+hYDniZssYhlXKKUMD5m8tF4Q==}
@@ -3180,7 +3189,6 @@ packages:
       '@babel/helper-string-parser': 7.22.5
       '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
-    dev: true
 
   /@base2/pretty-print-object@1.0.1:
     resolution: {integrity: sha512-4iri8i1AqYHJE2DstZYkyEprg6Pq6sKx3xn5FpySk9sNhH7qN2LLlHJCfDTZRILNwQNPD7mATWM0TBui7uC1pA==}
@@ -3451,15 +3459,6 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-arm@0.15.18:
-    resolution: {integrity: sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/android-arm@0.17.19:
     resolution: {integrity: sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==}
     engines: {node: '>=12'}
@@ -3698,15 +3697,6 @@ packages:
     resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
     engines: {node: '>=12'}
     cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-loong64@0.15.18:
-    resolution: {integrity: sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
     os: [linux]
     requiresBuild: true
     dev: true
@@ -4533,7 +4523,6 @@ packages:
 
   /@jridgewell/sourcemap-codec@1.4.15:
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
-    dev: true
 
   /@jridgewell/trace-mapping@0.3.17:
     resolution: {integrity: sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==}
@@ -6987,7 +6976,7 @@ packages:
       file-system-cache: 2.3.0
     dev: true
 
-  /@storybook/vue3-vite@7.0.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(vite@4.4.10)(vue@3.2.47):
+  /@storybook/vue3-vite@7.0.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(vite@4.4.10)(vue@3.4.21):
     resolution: {integrity: sha512-lmxnHA9wHkgbNq+oW6dVnXbe9QOFjOz4Ejkl1AAjjg0blJ+VGautVa3mSeYM99szx5EigSfQjFAkv/TAJVC80Q==}
     engines: {node: ^14.18 || >=16}
     peerDependencies:
@@ -6997,13 +6986,13 @@ packages:
     dependencies:
       '@storybook/builder-vite': 7.0.2(typescript@5.2.2)(vite@4.4.10)
       '@storybook/core-server': 7.0.2
-      '@storybook/vue3': 7.0.2(vue@3.2.47)
-      '@vitejs/plugin-vue': 4.1.0(vite@4.4.10)(vue@3.2.47)
+      '@storybook/vue3': 7.0.2(vue@3.4.21)
+      '@vitejs/plugin-vue': 4.1.0(vite@4.4.10)(vue@3.4.21)
       magic-string: 0.27.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       vite: 4.4.10
-      vue-docgen-api: 4.64.1(vue@3.2.47)
+      vue-docgen-api: 4.64.1(vue@3.4.21)
     transitivePeerDependencies:
       - '@preact/preset-vite'
       - '@storybook/mdx1-csf'
@@ -7016,7 +7005,7 @@ packages:
       - vue
     dev: true
 
-  /@storybook/vue3@7.0.2(vue@3.2.47):
+  /@storybook/vue3@7.0.2(vue@3.4.21):
     resolution: {integrity: sha512-0KDwhDYg9TQTB9awEcm8IeBMkxD6ZQFHuSHfE7TEWSx83H9pGb6CkVkAgjZlmfMiSY6gI160G4mJt2/tgTxbiA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -7029,7 +7018,7 @@ packages:
       '@storybook/types': 7.0.2
       ts-dedent: 2.2.0
       type-fest: 2.19.0
-      vue: 3.2.47
+      vue: 3.4.21(typescript@5.2.2)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7599,7 +7588,7 @@ packages:
     dependencies:
       '@types/prop-types': 15.7.8
       '@types/scheduler': 0.16.4
-      csstype: 3.1.2
+      csstype: 3.1.3
     dev: true
 
   /@types/rimraf@3.0.2:
@@ -7939,18 +7928,7 @@ packages:
       - supports-color
     dev: true
 
-  /@vitejs/plugin-vue@3.2.0(vite@3.2.7)(vue@3.2.47):
-    resolution: {integrity: sha512-E0tnaL4fr+qkdCNxJ+Xd0yM31UwMkQje76fsDVBBUCoGOUPexu2VDUYHL8P4CwV+zMvWw6nlRw19OnRKmYAJpw==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    peerDependencies:
-      vite: ^3.0.0
-      vue: ^3.2.25
-    dependencies:
-      vite: 3.2.7
-      vue: 3.2.47
-    dev: true
-
-  /@vitejs/plugin-vue@4.1.0(vite@4.4.10)(vue@3.2.47):
+  /@vitejs/plugin-vue@4.1.0(vite@4.4.10)(vue@3.4.21):
     resolution: {integrity: sha512-++9JOAFdcXI3lyer9UKUV4rfoQ3T1RN8yDqoCLar86s0xQct5yblxAE+yWgRnU5/0FOlVCpTZpYSBV/bGWrSrQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -7958,7 +7936,7 @@ packages:
       vue: ^3.2.25
     dependencies:
       vite: 4.4.10
-      vue: 3.2.47
+      vue: 3.4.21(typescript@5.2.2)
     dev: true
 
   /@vitest/expect@0.29.8:
@@ -7992,46 +7970,26 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
-  /@volar/language-core@1.3.0-alpha.0:
-    resolution: {integrity: sha512-W3uMzecHPcbwddPu4SJpUcPakRBK/y/BP+U0U6NiPpUX1tONLC4yCawt+QBJqtgJ+sfD6ztf5PyvPL3hQRqfOA==}
+  /@volar/language-core@2.1.5:
+    resolution: {integrity: sha512-u1OHmVkCFsJqNdaM2GKuMhE67TxcEnOqJNF+VtYv2Ji8DnrUaF4FAFSNxY+MRGICl+873CsSJVKas9TQtW14LA==}
     dependencies:
-      '@volar/source-map': 1.3.0-alpha.0
+      '@volar/source-map': 2.1.5
     dev: true
 
-  /@volar/source-map@1.3.0-alpha.0:
-    resolution: {integrity: sha512-jSdizxWFvDTvkPYZnO6ew3sBZUnS0abKCbuopkc0JrIlFbznWC/fPH3iPFIMS8/IIkRxq1Jh9VVG60SmtsdaMQ==}
+  /@volar/source-map@2.1.5:
+    resolution: {integrity: sha512-GIkAM6fHgDcTXcdH4i10fAiAZzO0HLIer8/pt3oZ9A0n7n4R5d1b2F8Xxzh/pgmgNoL+SrHX3MFxs35CKgfmtA==}
     dependencies:
-      muggle-string: 0.2.2
+      muggle-string: 0.4.1
     dev: true
 
-  /@volar/typescript@1.3.0-alpha.0:
-    resolution: {integrity: sha512-5UItyW2cdH2mBLu4RrECRNJRgtvvzKrSCn2y3v/D61QwIDkGx4aeil6x8RFuUL5TFtV6QvVHXnsOHxNgd+sCow==}
+  /@volar/typescript@2.1.5:
+    resolution: {integrity: sha512-zo9a3NrNMSkufIvHuExDGTfYv+zO7C5p2wg8fyP7vcqF/Qo0ztjb0ZfOgq/A85EO/MBc1Kj2Iu7PaOBtP++NMw==}
     dependencies:
-      '@volar/language-core': 1.3.0-alpha.0
+      '@volar/language-core': 2.1.5
+      path-browserify: 1.0.1
     dev: true
 
-  /@volar/vue-language-core@1.2.0:
-    resolution: {integrity: sha512-w7yEiaITh2WzKe6u8ZdeLKCUz43wdmY/OqAmsB/PGDvvhTcVhCJ6f0W/RprZL1IhqH8wALoWiwEh/Wer7ZviMQ==}
-    dependencies:
-      '@volar/language-core': 1.3.0-alpha.0
-      '@volar/source-map': 1.3.0-alpha.0
-      '@vue/compiler-dom': 3.2.47
-      '@vue/compiler-sfc': 3.2.47
-      '@vue/reactivity': 3.2.47
-      '@vue/shared': 3.2.47
-      minimatch: 6.2.0
-      muggle-string: 0.2.2
-      vue-template-compiler: 2.7.14
-    dev: true
-
-  /@volar/vue-typescript@1.2.0:
-    resolution: {integrity: sha512-zjmRi9y3J1EkG+pfuHp8IbHmibihrKK485cfzsHjiuvJMGrpkWvlO5WVEk8oslMxxeGC5XwBFE9AOlvh378EPA==}
-    dependencies:
-      '@volar/typescript': 1.3.0-alpha.0
-      '@volar/vue-language-core': 1.2.0
-    dev: true
-
-  /@vue-macros/common@1.1.4(vue@3.2.47):
+  /@vue-macros/common@1.1.4(vue@3.4.21):
     resolution: {integrity: sha512-LyTvNEffxbsWTq6dEUhJQZhAjwHvyQy5L2IhkJ3VQgecoxhFz62VmGWBst43l9RGHrhGLKaEa3euV0/6VJLqzQ==}
     engines: {node: '>=14.19.0'}
     peerDependencies:
@@ -8042,89 +8000,98 @@ packages:
     dependencies:
       '@babel/types': 7.21.3
       '@rollup/pluginutils': 5.0.2
-      '@vue/compiler-sfc': 3.2.47
+      '@vue/compiler-sfc': 3.4.21
       local-pkg: 0.4.3
       magic-string-ast: 0.1.2
-      vue: 3.2.47
+      vue: 3.4.21(typescript@5.2.2)
     transitivePeerDependencies:
       - rollup
     dev: true
 
-  /@vue/compiler-core@3.2.47:
-    resolution: {integrity: sha512-p4D7FDnQb7+YJmO2iPEv0SQNeNzcbHdGByJDsT4lynf63AFkOTFN07HsiRSvjGo0QrxR/o3d0hUyNCUnBU2Tig==}
+  /@vue/compiler-core@3.4.21:
+    resolution: {integrity: sha512-MjXawxZf2SbZszLPYxaFCjxfibYrzr3eYbKxwpLR9EQN+oaziSu3qKVbwBERj1IFIB8OLUewxB5m/BFzi613og==}
     dependencies:
-      '@babel/parser': 7.21.3
-      '@vue/shared': 3.2.47
+      '@babel/parser': 7.24.1
+      '@vue/shared': 3.4.21
+      entities: 4.5.0
       estree-walker: 2.0.2
-      source-map: 0.6.1
+      source-map-js: 1.2.0
 
-  /@vue/compiler-dom@3.2.47:
-    resolution: {integrity: sha512-dBBnEHEPoftUiS03a4ggEig74J2YBZ2UIeyfpcRM2tavgMWo4bsEfgCGsu+uJIL/vax9S+JztH8NmQerUo7shQ==}
+  /@vue/compiler-dom@3.4.21:
+    resolution: {integrity: sha512-IZC6FKowtT1sl0CR5DpXSiEB5ayw75oT2bma1BEhV7RRR1+cfwLrxc2Z8Zq/RGFzJ8w5r9QtCOvTjQgdn0IKmA==}
     dependencies:
-      '@vue/compiler-core': 3.2.47
-      '@vue/shared': 3.2.47
+      '@vue/compiler-core': 3.4.21
+      '@vue/shared': 3.4.21
 
-  /@vue/compiler-sfc@3.2.47:
-    resolution: {integrity: sha512-rog05W+2IFfxjMcFw10tM9+f7i/+FFpZJJ5XHX72NP9eC2uRD+42M3pYcQqDXVYoj74kHMSEdQ/WmCjt8JFksQ==}
+  /@vue/compiler-sfc@3.4.21:
+    resolution: {integrity: sha512-me7epoTxYlY+2CUM7hy9PCDdpMPfIwrOvAXud2Upk10g4YLv9UBW7kL798TvMeDhPthkZ0CONNrK2GoeI1ODiQ==}
     dependencies:
-      '@babel/parser': 7.21.3
-      '@vue/compiler-core': 3.2.47
-      '@vue/compiler-dom': 3.2.47
-      '@vue/compiler-ssr': 3.2.47
-      '@vue/reactivity-transform': 3.2.47
-      '@vue/shared': 3.2.47
+      '@babel/parser': 7.24.1
+      '@vue/compiler-core': 3.4.21
+      '@vue/compiler-dom': 3.4.21
+      '@vue/compiler-ssr': 3.4.21
+      '@vue/shared': 3.4.21
       estree-walker: 2.0.2
-      magic-string: 0.25.9
-      postcss: 8.4.21
-      source-map: 0.6.1
+      magic-string: 0.30.8
+      postcss: 8.4.38
+      source-map-js: 1.2.0
 
-  /@vue/compiler-ssr@3.2.47:
-    resolution: {integrity: sha512-wVXC+gszhulcMD8wpxMsqSOpvDZ6xKXSVWkf50Guf/S+28hTAXPDYRTbLQ3EDkOP5Xz/+SY37YiwDquKbJOgZw==}
+  /@vue/compiler-ssr@3.4.21:
+    resolution: {integrity: sha512-M5+9nI2lPpAsgXOGQobnIueVqc9sisBFexh5yMIMRAPYLa7+5wEJs8iqOZc1WAa9WQbx9GR2twgznU8LTIiZ4Q==}
     dependencies:
-      '@vue/compiler-dom': 3.2.47
-      '@vue/shared': 3.2.47
+      '@vue/compiler-dom': 3.4.21
+      '@vue/shared': 3.4.21
 
-  /@vue/devtools-api@6.5.0:
-    resolution: {integrity: sha512-o9KfBeaBmCKl10usN4crU53fYtC1r7jJwdGKjPT24t348rHxgfpZ0xL3Xm/gLUYnc0oTp8LAmrxOeLyu6tbk2Q==}
+  /@vue/devtools-api@6.6.1:
+    resolution: {integrity: sha512-LgPscpE3Vs0x96PzSSB4IGVSZXZBZHpfxs+ZA1d+VEPwHdOXowy/Y2CsvCAIFrf+ssVU1pD1jidj505EpUnfbA==}
 
-  /@vue/reactivity-transform@3.2.47:
-    resolution: {integrity: sha512-m8lGXw8rdnPVVIdIFhf0LeQ/ixyHkH5plYuS83yop5n7ggVJU+z5v0zecwEnX7fa7HNLBhh2qngJJkxpwEEmYA==}
-    dependencies:
-      '@babel/parser': 7.21.3
-      '@vue/compiler-core': 3.2.47
-      '@vue/shared': 3.2.47
-      estree-walker: 2.0.2
-      magic-string: 0.25.9
-
-  /@vue/reactivity@3.2.47:
-    resolution: {integrity: sha512-7khqQ/75oyyg+N/e+iwV6lpy1f5wq759NdlS1fpAhFXa8VeAIKGgk2E/C4VF59lx5b+Ezs5fpp/5WsRYXQiKxQ==}
-    dependencies:
-      '@vue/shared': 3.2.47
-
-  /@vue/runtime-core@3.2.47:
-    resolution: {integrity: sha512-RZxbLQIRB/K0ev0K9FXhNbBzT32H9iRtYbaXb0ZIz2usLms/D55dJR2t6cIEUn6vyhS3ALNvNthI+Q95C+NOpA==}
-    dependencies:
-      '@vue/reactivity': 3.2.47
-      '@vue/shared': 3.2.47
-
-  /@vue/runtime-dom@3.2.47:
-    resolution: {integrity: sha512-ArXrFTjS6TsDei4qwNvgrdmHtD930KgSKGhS5M+j8QxXrDJYLqYw4RRcDy1bz1m1wMmb6j+zGLifdVHtkXA7gA==}
-    dependencies:
-      '@vue/runtime-core': 3.2.47
-      '@vue/shared': 3.2.47
-      csstype: 2.6.21
-
-  /@vue/server-renderer@3.2.47(vue@3.2.47):
-    resolution: {integrity: sha512-dN9gc1i8EvmP9RCzvneONXsKfBRgqFeFZLurmHOveL7oH6HiFXJw5OGu294n1nHc/HMgTy6LulU/tv5/A7f/LA==}
+  /@vue/language-core@2.0.7(typescript@5.2.2):
+    resolution: {integrity: sha512-Vh1yZX3XmYjn9yYLkjU8DN6L0ceBtEcapqiyclHne8guG84IaTzqtvizZB1Yfxm3h6m7EIvjerLO5fvOZO6IIQ==}
     peerDependencies:
-      vue: 3.2.47
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
     dependencies:
-      '@vue/compiler-ssr': 3.2.47
-      '@vue/shared': 3.2.47
-      vue: 3.2.47
+      '@volar/language-core': 2.1.5
+      '@vue/compiler-dom': 3.4.21
+      '@vue/shared': 3.4.21
+      computeds: 0.0.1
+      minimatch: 9.0.3
+      path-browserify: 1.0.1
+      typescript: 5.2.2
+      vue-template-compiler: 2.7.14
+    dev: true
 
-  /@vue/shared@3.2.47:
-    resolution: {integrity: sha512-BHGyyGN3Q97EZx0taMQ+OLNuZcW3d37ZEVmEAyeoA9ERdGvm9Irc/0Fua8SNyOtV1w6BS4q25wbMzJujO9HIfQ==}
+  /@vue/reactivity@3.4.21:
+    resolution: {integrity: sha512-UhenImdc0L0/4ahGCyEzc/pZNwVgcglGy9HVzJ1Bq2Mm9qXOpP8RyNTjookw/gOCUlXSEtuZ2fUg5nrHcoqJcw==}
+    dependencies:
+      '@vue/shared': 3.4.21
+
+  /@vue/runtime-core@3.4.21:
+    resolution: {integrity: sha512-pQthsuYzE1XcGZznTKn73G0s14eCJcjaLvp3/DKeYWoFacD9glJoqlNBxt3W2c5S40t6CCcpPf+jG01N3ULyrA==}
+    dependencies:
+      '@vue/reactivity': 3.4.21
+      '@vue/shared': 3.4.21
+
+  /@vue/runtime-dom@3.4.21:
+    resolution: {integrity: sha512-gvf+C9cFpevsQxbkRBS1NpU8CqxKw0ebqMvLwcGQrNpx6gqRDodqKqA+A2VZZpQ9RpK2f9yfg8VbW/EpdFUOJw==}
+    dependencies:
+      '@vue/runtime-core': 3.4.21
+      '@vue/shared': 3.4.21
+      csstype: 3.1.3
+
+  /@vue/server-renderer@3.4.21(vue@3.4.21):
+    resolution: {integrity: sha512-aV1gXyKSN6Rz+6kZ6kr5+Ll14YzmIbeuWe7ryJl5muJ4uwSwY/aStXTixx76TwkZFJLm1aAlA/HSWEJ4EyiMkg==}
+    peerDependencies:
+      vue: 3.4.21
+    dependencies:
+      '@vue/compiler-ssr': 3.4.21
+      '@vue/shared': 3.4.21
+      vue: 3.4.21(typescript@5.2.2)
+
+  /@vue/shared@3.4.21:
+    resolution: {integrity: sha512-PuJe7vDIi6VYSinuEbUIQgMIRZGgM8e4R+G+/dQTk0X1NEdvgvvgv7m+rfmDH1gZzyA1OjjoWskvHlfRNfQf3g==}
 
   /@webassemblyjs/ast@1.9.0:
     resolution: {integrity: sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==}
@@ -8937,7 +8904,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@babel/template': 7.20.7
-      '@babel/types': 7.21.3
+      '@babel/types': 7.23.0
       '@types/babel__core': 7.20.2
       '@types/babel__traverse': 7.20.2
     dev: true
@@ -9077,7 +9044,7 @@ packages:
     resolution: {integrity: sha512-GAwkz0AihzY5bkwIY5QDR+LvsRQgB/B+1foMPvi0FZPMl5fjD7ICiznUiBdLYMH1QYe6vqu4gWYytZOccLouFw==}
     engines: {node: '>= 10.0.0'}
     dependencies:
-      '@babel/types': 7.21.4
+      '@babel/types': 7.23.0
     dev: true
 
   /bail@1.0.5:
@@ -10004,6 +9971,10 @@ packages:
       - supports-color
     dev: true
 
+  /computeds@0.0.1:
+    resolution: {integrity: sha512-7CEBgcMjVmitjYo5q8JTJVra6X5mQ20uTThdK+0kR7UEaDrAWEQcRiBtWJzga4eRpP6afNwwLsX2SET2JhVB1Q==}
+    dev: true
+
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: true
@@ -10045,8 +10016,8 @@ packages:
   /constantinople@4.0.1:
     resolution: {integrity: sha512-vCrqcSIq4//Gx74TXXCGnHpulY1dskqLTFGDmhrGxzeXL8lF8kvXv6mpNWlJj1uD4DW23D4ljAqbY4RRaaUZIw==}
     dependencies:
-      '@babel/parser': 7.21.3
-      '@babel/types': 7.21.4
+      '@babel/parser': 7.24.1
+      '@babel/types': 7.23.0
     dev: true
 
   /constants-browserify@1.0.0:
@@ -10288,16 +10259,12 @@ packages:
       rrweb-cssom: 0.6.0
     dev: true
 
-  /csstype@2.6.21:
-    resolution: {integrity: sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==}
-
   /csstype@3.1.1:
     resolution: {integrity: sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==}
     dev: true
 
-  /csstype@3.1.2:
-    resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
-    dev: true
+  /csstype@3.1.3:
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   /csv-generate@3.4.3:
     resolution: {integrity: sha512-w/T+rqR0vwvHqWs/1ZyMDWtHHSJaN06klRqJXBEpDJaM/+dZkso0OKh1VcuuYvK3XM53KysVNq8Ko/epCK8wOw==}
@@ -10880,6 +10847,10 @@ packages:
     engines: {node: '>=0.12'}
     dev: true
 
+  /entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
   /envinfo@7.10.0:
     resolution: {integrity: sha512-ZtUjZO6l5mwTHvc1L9+1q5p/R3wTopcfqMW8r5t8SJSKqeVI/LtajORwRFEKpEFuekjD0VBjwu1HMxL4UalIRw==}
     engines: {node: '>=4'}
@@ -10993,150 +10964,6 @@ packages:
     resolution: {integrity: sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw==}
     dev: true
 
-  /esbuild-android-64@0.15.18:
-    resolution: {integrity: sha512-wnpt3OXRhcjfIDSZu9bnzT4/TNTDsOUvip0foZOUBG7QbSt//w3QV4FInVJxNhKc/ErhUxc5z4QjHtMi7/TbgA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-android-arm64@0.15.18:
-    resolution: {integrity: sha512-G4xu89B8FCzav9XU8EjsXacCKSG2FT7wW9J6hOc18soEHJdtWu03L3TQDGf0geNxfLTtxENKBzMSq9LlbjS8OQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-darwin-64@0.15.18:
-    resolution: {integrity: sha512-2WAvs95uPnVJPuYKP0Eqx+Dl/jaYseZEUUT1sjg97TJa4oBtbAKnPnl3b5M9l51/nbx7+QAEtuummJZW0sBEmg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-darwin-arm64@0.15.18:
-    resolution: {integrity: sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-freebsd-64@0.15.18:
-    resolution: {integrity: sha512-TT3uBUxkteAjR1QbsmvSsjpKjOX6UkCstr8nMr+q7zi3NuZ1oIpa8U41Y8I8dJH2fJgdC3Dj3CXO5biLQpfdZA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-freebsd-arm64@0.15.18:
-    resolution: {integrity: sha512-R/oVr+X3Tkh+S0+tL41wRMbdWtpWB8hEAMsOXDumSSa6qJR89U0S/PpLXrGF7Wk/JykfpWNokERUpCeHDl47wA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-32@0.15.18:
-    resolution: {integrity: sha512-lphF3HiCSYtaa9p1DtXndiQEeQDKPl9eN/XNoBf2amEghugNuqXNZA/ZovthNE2aa4EN43WroO0B85xVSjYkbg==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-64@0.15.18:
-    resolution: {integrity: sha512-hNSeP97IviD7oxLKFuii5sDPJ+QHeiFTFLoLm7NZQligur8poNOWGIgpQ7Qf8Balb69hptMZzyOBIPtY09GZYw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-arm64@0.15.18:
-    resolution: {integrity: sha512-54qr8kg/6ilcxd+0V3h9rjT4qmjc0CccMVWrjOEM/pEcUzt8X62HfBSeZfT2ECpM7104mk4yfQXkosY8Quptug==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-arm@0.15.18:
-    resolution: {integrity: sha512-UH779gstRblS4aoS2qpMl3wjg7U0j+ygu3GjIeTonCcN79ZvpPee12Qun3vcdxX+37O5LFxz39XeW2I9bybMVA==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-mips64le@0.15.18:
-    resolution: {integrity: sha512-Mk6Ppwzzz3YbMl/ZZL2P0q1tnYqh/trYZ1VfNP47C31yT0K8t9s7Z077QrDA/guU60tGNp2GOwCQnp+DYv7bxQ==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-ppc64le@0.15.18:
-    resolution: {integrity: sha512-b0XkN4pL9WUulPTa/VKHx2wLCgvIAbgwABGnKMY19WhKZPT+8BxhZdqz6EgkqCLld7X5qiCY2F/bfpUUlnFZ9w==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-riscv64@0.15.18:
-    resolution: {integrity: sha512-ba2COaoF5wL6VLZWn04k+ACZjZ6NYniMSQStodFKH/Pu6RxzQqzsmjR1t9QC89VYJxBeyVPTaHuBMCejl3O/xg==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-s390x@0.15.18:
-    resolution: {integrity: sha512-VbpGuXEl5FCs1wDVp93O8UIzl3ZrglgnSQ+Hu79g7hZu6te6/YHgVJxCM2SqfIila0J3k0csfnf8VD2W7u2kzQ==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-netbsd-64@0.15.18:
-    resolution: {integrity: sha512-98ukeCdvdX7wr1vUYQzKo4kQ0N2p27H7I11maINv73fVEXt2kyh4K4m9f35U1K43Xc2QGXlzAw0K9yoU7JUjOg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-openbsd-64@0.15.18:
-    resolution: {integrity: sha512-yK5NCcH31Uae076AyQAXeJzt/vxIo9+omZRKj1pauhk3ITuADzuOx5N2fdHrAKPxN+zH3w96uFKlY7yIn490xQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /esbuild-plugin-alias@0.2.1:
     resolution: {integrity: sha512-jyfL/pwPqaFXyKnj8lP8iLk6Z0m099uXR45aSN8Av1XD4vhvQutxxPzgA2bTcAwQpa1zCXDcWOlhFgyP3GKqhQ==}
     dev: true
@@ -11161,72 +10988,6 @@ packages:
       esbuild: 0.18.20
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /esbuild-sunos-64@0.15.18:
-    resolution: {integrity: sha512-On22LLFlBeLNj/YF3FT+cXcyKPEI263nflYlAhz5crxtp3yRG1Ugfr7ITyxmCmjm4vbN/dGrb/B7w7U8yJR9yw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-windows-32@0.15.18:
-    resolution: {integrity: sha512-o+eyLu2MjVny/nt+E0uPnBxYuJHBvho8vWsC2lV61A7wwTWC3jkN2w36jtA+yv1UgYkHRihPuQsL23hsCYGcOQ==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-windows-64@0.15.18:
-    resolution: {integrity: sha512-qinug1iTTaIIrCorAUjR0fcBk24fjzEedFYhhispP8Oc7SFvs+XeW3YpAKiKp8dRpizl4YYAhxMjlftAMJiaUw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-windows-arm64@0.15.18:
-    resolution: {integrity: sha512-q9bsYzegpZcLziq0zgUi5KqGVtfhjxGbnksaBFYmWLxeV/S1fK4OLdq2DFYnXcLMjlZw2L0jLsk1eGoB522WXQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild@0.15.18:
-    resolution: {integrity: sha512-x/R72SmW3sSFRm5zrrIjAhCeQSAWoni3CmHEqfQrZIQTM3lVCdehdwuIqaOtfC2slvpdlLa62GYoN8SxT23m6Q==}
-    engines: {node: '>=12'}
-    hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      '@esbuild/android-arm': 0.15.18
-      '@esbuild/linux-loong64': 0.15.18
-      esbuild-android-64: 0.15.18
-      esbuild-android-arm64: 0.15.18
-      esbuild-darwin-64: 0.15.18
-      esbuild-darwin-arm64: 0.15.18
-      esbuild-freebsd-64: 0.15.18
-      esbuild-freebsd-arm64: 0.15.18
-      esbuild-linux-32: 0.15.18
-      esbuild-linux-64: 0.15.18
-      esbuild-linux-arm: 0.15.18
-      esbuild-linux-arm64: 0.15.18
-      esbuild-linux-mips64le: 0.15.18
-      esbuild-linux-ppc64le: 0.15.18
-      esbuild-linux-riscv64: 0.15.18
-      esbuild-linux-s390x: 0.15.18
-      esbuild-netbsd-64: 0.15.18
-      esbuild-openbsd-64: 0.15.18
-      esbuild-sunos-64: 0.15.18
-      esbuild-windows-32: 0.15.18
-      esbuild-windows-64: 0.15.18
-      esbuild-windows-arm64: 0.15.18
     dev: true
 
   /esbuild@0.17.19:
@@ -12258,7 +12019,7 @@ packages:
       memfs: 3.4.13
       minimatch: 3.1.2
       schema-utils: 2.7.0
-      semver: 7.3.8
+      semver: 7.5.4
       tapable: 1.1.3
       typescript: 5.0.2
       webpack: 4.46.0
@@ -14414,7 +14175,7 @@ packages:
       jest-util: 28.1.3
       natural-compare: 1.4.0
       pretty-format: 28.1.3
-      semver: 7.3.8
+      semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -15095,23 +14856,11 @@ packages:
     resolution: {integrity: sha512-P53AZrzq7hclCU6HWj88xNZHmP15DKjMmK/vBytO1qnpYP3ul4IEZlyCE0aU3JRnmgWmZPmoTKj4Bls7v0pMyA==}
     engines: {node: '>=14.19.0'}
     dependencies:
-      magic-string: 0.30.0
+      magic-string: 0.30.8
     dev: true
-
-  /magic-string@0.25.9:
-    resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
-    dependencies:
-      sourcemap-codec: 1.4.8
 
   /magic-string@0.27.0:
     resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
-    engines: {node: '>=12'}
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.14
-    dev: true
-
-  /magic-string@0.30.0:
-    resolution: {integrity: sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==}
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.14
@@ -15123,6 +14872,12 @@ packages:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
+
+  /magic-string@0.30.8:
+    resolution: {integrity: sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
 
   /make-dir@2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
@@ -15136,7 +14891,7 @@ packages:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
     engines: {node: '>=8'}
     dependencies:
-      semver: 6.3.0
+      semver: 6.3.1
     dev: true
 
   /make-error@1.3.6:
@@ -15474,13 +15229,6 @@ packages:
       brace-expansion: 2.0.1
     dev: true
 
-  /minimatch@6.2.0:
-    resolution: {integrity: sha512-sauLxniAmvnhhRjFwPNnJKaPFYyddAgbYdeUpHULtCT/GhzdCx/MDNy+Y40lBxTQUrMzDE8e0S43Z5uqfO0REg==}
-    engines: {node: '>=10'}
-    dependencies:
-      brace-expansion: 2.0.1
-    dev: true
-
   /minimatch@8.0.3:
     resolution: {integrity: sha512-tEEvU9TkZgnFDCtpnrEYnPsjT7iUx42aXfs4bzmQ5sMA09/6hZY0jeZcGkXyDagiBOvkUjNo8Viom+Me6+2x7g==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -15625,8 +15373,8 @@ packages:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
     dev: true
 
-  /muggle-string@0.2.2:
-    resolution: {integrity: sha512-YVE1mIJ4VpUMqZObFndk9CJu6DBJR/GB13p3tXuNbwD4XExaI5EOuRl6BHeIDxIqXZVxSfAC+y6U1Z/IxCfKUg==}
+  /muggle-string@0.4.1:
+    resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
     dev: true
 
   /mustache@4.2.0:
@@ -15646,6 +15394,12 @@ packages:
 
   /nanoid@3.3.6:
     resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+    dev: true
+
+  /nanoid@3.3.7:
+    resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -15790,7 +15544,7 @@ packages:
     dependencies:
       hosted-git-info: 4.1.0
       is-core-module: 2.11.0
-      semver: 7.3.8
+      semver: 7.5.4
       validate-npm-package-license: 3.0.4
     dev: true
 
@@ -16632,6 +16386,7 @@ packages:
       nanoid: 3.3.6
       picocolors: 1.0.0
       source-map-js: 1.0.2
+    dev: true
 
   /postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -16641,6 +16396,14 @@ packages:
       picocolors: 1.0.0
       source-map-js: 1.0.2
     dev: true
+
+  /postcss@8.4.38:
+    resolution: {integrity: sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.7
+      picocolors: 1.0.0
+      source-map-js: 1.2.0
 
   /preferred-pm@3.0.3:
     resolution: {integrity: sha512-+wZgbxNES/KlJs9q40F/1sfOd/j7f1O9JaHcW5Dsn3aUUOZg3L2bjpVUcKV2jvtElYfoTuQiNeMfQJ4kwUAhCQ==}
@@ -17866,14 +17629,6 @@ packages:
       yargs: 17.7.1
     dev: true
 
-  /rollup@2.79.1:
-    resolution: {integrity: sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==}
-    engines: {node: '>=10.0.0'}
-    hasBin: true
-    optionalDependencies:
-      fsevents: 2.3.3
-    dev: true
-
   /rollup@3.20.2:
     resolution: {integrity: sha512-3zwkBQl7Ai7MFYQE0y1MeQ15+9jsi7XxfrqwTb/9EK8D9C9+//EBR4M+CuA1KODRaNbFez/lWxA5vhEGZp4MUg==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
@@ -18286,6 +18041,11 @@ packages:
   /source-map-js@1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /source-map-js@1.2.0:
+    resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
+    engines: {node: '>=0.10.0'}
 
   /source-map-resolve@0.5.3:
     resolution: {integrity: sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==}
@@ -18330,15 +18090,12 @@ packages:
   /source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /source-map@0.7.4:
     resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
     engines: {node: '>= 8'}
     dev: true
-
-  /sourcemap-codec@1.4.8:
-    resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
-    deprecated: Please use @jridgewell/sourcemap-codec instead
 
   /space-separated-tokens@1.1.5:
     resolution: {integrity: sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==}
@@ -19389,7 +19146,6 @@ packages:
     resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
     engines: {node: '>=14.17'}
     hasBin: true
-    dev: true
 
   /ufo@1.1.1:
     resolution: {integrity: sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==}
@@ -19570,11 +19326,11 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
-  /unplugin-vue-define-options@1.3.2(vue@3.2.47):
+  /unplugin-vue-define-options@1.3.2(vue@3.4.21):
     resolution: {integrity: sha512-12NkDmw4RWV5ob5GMMrpuFczW/zvLM1CByiOu/Ev5loOLh+7pV+JLehQk3sAXMi3Za9W6Dktnt5/LLH9OGsQgw==}
     engines: {node: '>=14.19.0'}
     dependencies:
-      '@vue-macros/common': 1.1.4(vue@3.2.47)
+      '@vue-macros/common': 1.1.4(vue@3.4.21)
       ast-walker-scope: 0.4.1
       unplugin: 1.3.1
     transitivePeerDependencies:
@@ -19930,39 +19686,6 @@ packages:
       - supports-color
     dev: true
 
-  /vite@3.2.7:
-    resolution: {integrity: sha512-29pdXjk49xAP0QBr0xXqu2s5jiQIXNvE/xwd0vUizYT2Hzqe4BksNNoWllFVXJf4eLZ+UlVQmXfB4lWrc+t18g==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      esbuild: 0.15.18
-      postcss: 8.4.31
-      resolve: 1.22.6
-      rollup: 2.79.1
-    optionalDependencies:
-      fsevents: 2.3.3
-    dev: true
-
   /vite@4.4.10:
     resolution: {integrity: sha512-TzIjiqx9BEXF8yzYdF2NTf1kFFbjMjUSV0LFZ3HyHoI3SGSPLnnFUKiIQtL3gl2AjHvMrprOvQ3amzaHgQlAxw==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -19992,7 +19715,7 @@ packages:
         optional: true
     dependencies:
       esbuild: 0.18.20
-      postcss: 8.4.31
+      postcss: 8.4.38
       rollup: 3.29.4
     optionalDependencies:
       fsevents: 2.3.3
@@ -20110,20 +19833,20 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /vue-docgen-api@4.64.1(vue@3.2.47):
+  /vue-docgen-api@4.64.1(vue@3.4.21):
     resolution: {integrity: sha512-jbOf7ByE3Zvtuk+429Jorl+eIeh2aB2Fx1GUo3xJd1aByJWE8KDlSEa6b11PB1ze8f0sRUBraRDinICCk0KY7g==}
     dependencies:
       '@babel/parser': 7.21.3
       '@babel/types': 7.21.3
-      '@vue/compiler-dom': 3.2.47
-      '@vue/compiler-sfc': 3.2.47
+      '@vue/compiler-dom': 3.4.21
+      '@vue/compiler-sfc': 3.4.21
       ast-types: 0.14.2
       hash-sum: 2.0.0
       lru-cache: 8.0.4
       pug: 3.0.2
       recast: 0.22.0
       ts-map: 1.0.3
-      vue-inbrowser-compiler-independent-utils: 4.64.1(vue@3.2.47)
+      vue-inbrowser-compiler-independent-utils: 4.64.1(vue@3.4.21)
     transitivePeerDependencies:
       - vue
     dev: true
@@ -20146,21 +19869,21 @@ packages:
       - supports-color
     dev: true
 
-  /vue-inbrowser-compiler-independent-utils@4.64.1(vue@3.2.47):
+  /vue-inbrowser-compiler-independent-utils@4.64.1(vue@3.4.21):
     resolution: {integrity: sha512-Hn32n07XZ8j9W8+fmOXPQL+i+W2e/8i6mkH4Ju3H6nR0+cfvmWM95GhczYi5B27+Y8JlCKgAo04IUiYce4mKAw==}
     peerDependencies:
       vue: '>=2'
     dependencies:
-      vue: 3.2.47
+      vue: 3.4.21(typescript@5.2.2)
     dev: true
 
-  /vue-router@4.1.6(vue@3.2.47):
-    resolution: {integrity: sha512-DYWYwsG6xNPmLq/FmZn8Ip+qrhFEzA14EI12MsMgVxvHFDYvlr4NXpVF5hrRH1wVcDP8fGi5F4rxuJSl8/r+EQ==}
+  /vue-router@4.3.0(vue@3.4.21):
+    resolution: {integrity: sha512-dqUcs8tUeG+ssgWhcPbjHvazML16Oga5w34uCUmsk7i0BcnskoLGwjpa15fqMr2Fa5JgVBrdL2MEgqz6XZ/6IQ==}
     peerDependencies:
       vue: ^3.2.0
     dependencies:
-      '@vue/devtools-api': 6.5.0
-      vue: 3.2.47
+      '@vue/devtools-api': 6.6.1
+      vue: 3.4.21(typescript@5.2.2)
 
   /vue-template-compiler@2.7.14:
     resolution: {integrity: sha512-zyA5Y3ArvVG0NacJDkkzJuPQDF8RFeRlzV2vLeSnhSpieO6LK2OVbdLPi5MPPs09Ii+gMO8nY4S3iKQxBxDmWQ==}
@@ -20169,25 +19892,32 @@ packages:
       he: 1.2.0
     dev: true
 
-  /vue-tsc@1.2.0(typescript@5.2.2):
-    resolution: {integrity: sha512-rIlzqdrhyPYyLG9zxsVRa+JEseeS9s8F2BbVVVWRRsTZvJO2BbhLEb2HW3MY+DFma0378tnIqs+vfTzbcQtRFw==}
+  /vue-tsc@2.0.7(typescript@5.2.2):
+    resolution: {integrity: sha512-LYa0nInkfcDBB7y8jQ9FQ4riJTRNTdh98zK/hzt4gEpBZQmf30dPhP+odzCa+cedGz6B/guvJEd0BavZaRptjg==}
     hasBin: true
     peerDependencies:
       typescript: '*'
     dependencies:
-      '@volar/vue-language-core': 1.2.0
-      '@volar/vue-typescript': 1.2.0
+      '@volar/typescript': 2.1.5
+      '@vue/language-core': 2.0.7(typescript@5.2.2)
+      semver: 7.5.4
       typescript: 5.2.2
     dev: true
 
-  /vue@3.2.47:
-    resolution: {integrity: sha512-60188y/9Dc9WVrAZeUVSDxRQOZ+z+y5nO2ts9jWXSTkMvayiWxCWOWtBQoYjLeccfXkiiPZWAHcV+WTPhkqJHQ==}
+  /vue@3.4.21(typescript@5.2.2):
+    resolution: {integrity: sha512-5hjyV/jLEIKD/jYl4cavMcnzKwjMKohureP8ejn3hhEjwhWIhWeuzL2kJAjzl/WyVsgPY56Sy4Z40C3lVshxXA==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
     dependencies:
-      '@vue/compiler-dom': 3.2.47
-      '@vue/compiler-sfc': 3.2.47
-      '@vue/runtime-dom': 3.2.47
-      '@vue/server-renderer': 3.2.47(vue@3.2.47)
-      '@vue/shared': 3.2.47
+      '@vue/compiler-dom': 3.4.21
+      '@vue/compiler-sfc': 3.4.21
+      '@vue/runtime-dom': 3.4.21
+      '@vue/server-renderer': 3.4.21(vue@3.4.21)
+      '@vue/shared': 3.4.21
+      typescript: 5.2.2
 
   /w3c-xmlserializer@4.0.0:
     resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}
@@ -20476,8 +20206,8 @@ packages:
     resolution: {integrity: sha512-RNGKj82nUPg3g5ygxkQl0R937xLyho1J24ItRCBTr/m1YnZkzJy1hUiHUJrc/VlsDQzsCnInEGSg3bci0Lmd4w==}
     engines: {node: '>= 10.0.0'}
     dependencies:
-      '@babel/parser': 7.21.3
-      '@babel/types': 7.21.4
+      '@babel/parser': 7.24.1
+      '@babel/types': 7.23.0
       assert-never: 1.2.1
       babel-walk: 3.0.0-canary-5
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,8 +81,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0(@typescript-eslint/eslint-plugin@5.57.0)(eslint@8.37.0)
       eslint-plugin-vue:
-        specifier: ^9.7.0
-        version: 9.10.0(eslint@8.37.0)
+        specifier: ^9.23.0
+        version: 9.23.0(eslint@8.37.0)
       http-server:
         specifier: ^14.1.1
         version: 14.1.1
@@ -11246,8 +11246,8 @@ packages:
       eslint-rule-composer: 0.3.0
     dev: true
 
-  /eslint-plugin-vue@9.10.0(eslint@8.37.0):
-    resolution: {integrity: sha512-2MgP31OBf8YilUvtakdVMc8xVbcMp7z7/iQj8LHVpXrSXHPXSJRUIGSPFI6b6pyCx/buKaFJ45ycqfHvQRiW2g==}
+  /eslint-plugin-vue@9.23.0(eslint@8.37.0):
+    resolution: {integrity: sha512-Bqd/b7hGYGrlV+wP/g77tjyFmp81lh5TMw0be9093X02SyelxRRfCI6/IsGq/J7Um0YwB9s0Ry0wlFyjPdmtUw==}
     engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.2.0 || ^7.0.0 || ^8.0.0
@@ -11256,9 +11256,9 @@ packages:
       eslint: 8.37.0
       natural-compare: 1.4.0
       nth-check: 2.1.1
-      postcss-selector-parser: 6.0.11
-      semver: 7.3.8
-      vue-eslint-parser: 9.1.0(eslint@8.37.0)
+      postcss-selector-parser: 6.0.16
+      semver: 7.6.0
+      vue-eslint-parser: 9.4.2(eslint@8.37.0)
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -16371,8 +16371,8 @@ packages:
       yaml: 1.10.2
     dev: true
 
-  /postcss-selector-parser@6.0.11:
-    resolution: {integrity: sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==}
+  /postcss-selector-parser@6.0.16:
+    resolution: {integrity: sha512-A0RVJrX+IUkVZbW3ClroRWurercFhieevHB38sr2+l9eUClMqome3LmEmnhlNy+5Mr2EYN6B2Kaw9wYdd+VHiw==}
     engines: {node: '>=4'}
     dependencies:
       cssesc: 3.0.0
@@ -17796,6 +17796,14 @@ packages:
 
   /semver@7.5.4:
     resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+    dev: true
+
+  /semver@7.6.0:
+    resolution: {integrity: sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
@@ -19851,8 +19859,8 @@ packages:
       - vue
     dev: true
 
-  /vue-eslint-parser@9.1.0(eslint@8.37.0):
-    resolution: {integrity: sha512-NGn/iQy8/Wb7RrRa4aRkokyCZfOUWk19OP5HP6JEozQFX5AoS/t+Z0ZN7FY4LlmWc4FNI922V7cvX28zctN8dQ==}
+  /vue-eslint-parser@9.4.2(eslint@8.37.0):
+    resolution: {integrity: sha512-Ry9oiGmCAK91HrKMtCrKFWmSFWvYkpGglCeFAIqDdr9zdXmMMpJOmUJS7WWsW7fX81h6mwHmUZCQQ1E0PkSwYQ==}
     engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '>=6.0.0'
@@ -19864,7 +19872,7 @@ packages:
       espree: 9.5.1
       esquery: 1.5.0
       lodash: 4.17.21
-      semver: 7.3.8
+      semver: 7.6.0
     transitivePeerDependencies:
       - supports-color
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,14 +172,14 @@ importers:
         version: 3.4.21(typescript@5.2.2)
     devDependencies:
       '@vitejs/plugin-vue':
-        specifier: ^4.1.0
-        version: 4.1.0(vite@4.4.10)(vue@3.4.21)
+        specifier: ^5.0.4
+        version: 5.0.4(vite@5.2.6)(vue@3.4.21)
       vue-router:
         specifier: ^4.1.6
         version: 4.3.0(vue@3.4.21)
       vue-tsc:
-        specifier: ^2.0.7
-        version: 2.0.7(typescript@5.2.2)
+        specifier: ^1.8.27
+        version: 1.8.27(typescript@5.2.2)
 
   packages/constants: {}
 
@@ -233,16 +233,16 @@ importers:
         version: 7.0.2(vue@3.4.21)
       '@storybook/vue3-vite':
         specifier: ^7.0.2
-        version: 7.0.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(vite@4.4.10)(vue@3.4.21)
+        version: 7.0.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(vite@4.4.9)(vue@3.4.21)
       '@vitejs/plugin-vue':
-        specifier: ^4.1.0
-        version: 4.1.0(vite@4.4.10)(vue@3.4.21)
+        specifier: ^5.0.4
+        version: 5.0.4(vite@4.4.9)(vue@3.4.21)
       unplugin-vue-define-options:
         specifier: ^1.1.1
         version: 1.3.2(vue@3.4.21)
       vue-tsc:
-        specifier: ^2.0.7
-        version: 2.0.7(typescript@5.2.2)
+        specifier: ^1.8.27
+        version: 1.8.27(typescript@5.2.2)
 
   packages/wiz-ui-react:
     dependencies:
@@ -3432,6 +3432,15 @@ packages:
       react: 18.2.0
     dev: true
 
+  /@esbuild/aix-ppc64@0.20.2:
+    resolution: {integrity: sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/android-arm64@0.17.19:
     resolution: {integrity: sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==}
     engines: {node: '>=12'}
@@ -3452,6 +3461,15 @@ packages:
 
   /@esbuild/android-arm64@0.18.20:
     resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm64@0.20.2:
+    resolution: {integrity: sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -3486,6 +3504,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/android-arm@0.20.2:
+    resolution: {integrity: sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/android-x64@0.17.19:
     resolution: {integrity: sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==}
     engines: {node: '>=12'}
@@ -3506,6 +3533,15 @@ packages:
 
   /@esbuild/android-x64@0.18.20:
     resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-x64@0.20.2:
+    resolution: {integrity: sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -3540,6 +3576,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/darwin-arm64@0.20.2:
+    resolution: {integrity: sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/darwin-x64@0.17.19:
     resolution: {integrity: sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==}
     engines: {node: '>=12'}
@@ -3560,6 +3605,15 @@ packages:
 
   /@esbuild/darwin-x64@0.18.20:
     resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-x64@0.20.2:
+    resolution: {integrity: sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -3594,6 +3648,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/freebsd-arm64@0.20.2:
+    resolution: {integrity: sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/freebsd-x64@0.17.19:
     resolution: {integrity: sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==}
     engines: {node: '>=12'}
@@ -3614,6 +3677,15 @@ packages:
 
   /@esbuild/freebsd-x64@0.18.20:
     resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-x64@0.20.2:
+    resolution: {integrity: sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -3648,6 +3720,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-arm64@0.20.2:
+    resolution: {integrity: sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-arm@0.17.19:
     resolution: {integrity: sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==}
     engines: {node: '>=12'}
@@ -3668,6 +3749,15 @@ packages:
 
   /@esbuild/linux-arm@0.18.20:
     resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm@0.20.2:
+    resolution: {integrity: sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -3702,6 +3792,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-ia32@0.20.2:
+    resolution: {integrity: sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-loong64@0.17.19:
     resolution: {integrity: sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==}
     engines: {node: '>=12'}
@@ -3722,6 +3821,15 @@ packages:
 
   /@esbuild/linux-loong64@0.18.20:
     resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64@0.20.2:
+    resolution: {integrity: sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -3756,6 +3864,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-mips64el@0.20.2:
+    resolution: {integrity: sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-ppc64@0.17.19:
     resolution: {integrity: sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==}
     engines: {node: '>=12'}
@@ -3776,6 +3893,15 @@ packages:
 
   /@esbuild/linux-ppc64@0.18.20:
     resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ppc64@0.20.2:
+    resolution: {integrity: sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -3810,6 +3936,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-riscv64@0.20.2:
+    resolution: {integrity: sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-s390x@0.17.19:
     resolution: {integrity: sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==}
     engines: {node: '>=12'}
@@ -3830,6 +3965,15 @@ packages:
 
   /@esbuild/linux-s390x@0.18.20:
     resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-s390x@0.20.2:
+    resolution: {integrity: sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -3864,6 +4008,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-x64@0.20.2:
+    resolution: {integrity: sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/netbsd-x64@0.17.19:
     resolution: {integrity: sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==}
     engines: {node: '>=12'}
@@ -3884,6 +4037,15 @@ packages:
 
   /@esbuild/netbsd-x64@0.18.20:
     resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/netbsd-x64@0.20.2:
+    resolution: {integrity: sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -3918,6 +4080,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/openbsd-x64@0.20.2:
+    resolution: {integrity: sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/sunos-x64@0.17.19:
     resolution: {integrity: sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==}
     engines: {node: '>=12'}
@@ -3938,6 +4109,15 @@ packages:
 
   /@esbuild/sunos-x64@0.18.20:
     resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/sunos-x64@0.20.2:
+    resolution: {integrity: sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -3972,6 +4152,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/win32-arm64@0.20.2:
+    resolution: {integrity: sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-ia32@0.17.19:
     resolution: {integrity: sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==}
     engines: {node: '>=12'}
@@ -3999,6 +4188,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/win32-ia32@0.20.2:
+    resolution: {integrity: sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-x64@0.17.19:
     resolution: {integrity: sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==}
     engines: {node: '>=12'}
@@ -4019,6 +4217,15 @@ packages:
 
   /@esbuild/win32-x64@0.18.20:
     resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-x64@0.20.2:
+    resolution: {integrity: sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -5229,6 +5436,110 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /@rollup/rollup-android-arm-eabi@4.13.0:
+    resolution: {integrity: sha512-5ZYPOuaAqEH/W3gYsRkxQATBW3Ii1MfaT4EQstTnLKViLi2gLSQmlmtTpGucNP3sXEpOiI5tdGhjdE111ekyEg==}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-android-arm64@4.13.0:
+    resolution: {integrity: sha512-BSbaCmn8ZadK3UAQdlauSvtaJjhlDEjS5hEVVIN3A4bbl3X+otyf/kOJV08bYiRxfejP3DXFzO2jz3G20107+Q==}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-darwin-arm64@4.13.0:
+    resolution: {integrity: sha512-Ovf2evVaP6sW5Ut0GHyUSOqA6tVKfrTHddtmxGQc1CTQa1Cw3/KMCDEEICZBbyppcwnhMwcDce9ZRxdWRpVd6g==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-darwin-x64@4.13.0:
+    resolution: {integrity: sha512-U+Jcxm89UTK592vZ2J9st9ajRv/hrwHdnvyuJpa5A2ngGSVHypigidkQJP+YiGL6JODiUeMzkqQzbCG3At81Gg==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm-gnueabihf@4.13.0:
+    resolution: {integrity: sha512-8wZidaUJUTIR5T4vRS22VkSMOVooG0F4N+JSwQXWSRiC6yfEsFMLTYRFHvby5mFFuExHa/yAp9juSphQQJAijQ==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-gnu@4.13.0:
+    resolution: {integrity: sha512-Iu0Kno1vrD7zHQDxOmvweqLkAzjxEVqNhUIXBsZ8hu8Oak7/5VTPrxOEZXYC1nmrBVJp0ZcL2E7lSuuOVaE3+w==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-musl@4.13.0:
+    resolution: {integrity: sha512-C31QrW47llgVyrRjIwiOwsHFcaIwmkKi3PCroQY5aVq4H0A5v/vVVAtFsI1nfBngtoRpeREvZOkIhmRwUKkAdw==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-riscv64-gnu@4.13.0:
+    resolution: {integrity: sha512-Oq90dtMHvthFOPMl7pt7KmxzX7E71AfyIhh+cPhLY9oko97Zf2C9tt/XJD4RgxhaGeAraAXDtqxvKE1y/j35lA==}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-gnu@4.13.0:
+    resolution: {integrity: sha512-yUD/8wMffnTKuiIsl6xU+4IA8UNhQ/f1sAnQebmE/lyQ8abjsVyDkyRkWop0kdMhKMprpNIhPmYlCxgHrPoXoA==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-musl@4.13.0:
+    resolution: {integrity: sha512-9RyNqoFNdF0vu/qqX63fKotBh43fJQeYC98hCaf89DYQpv+xu0D8QFSOS0biA7cGuqJFOc1bJ+m2rhhsKcw1hw==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-arm64-msvc@4.13.0:
+    resolution: {integrity: sha512-46ue8ymtm/5PUU6pCvjlic0z82qWkxv54GTJZgHrQUuZnVH+tvvSP0LsozIDsCBFO4VjJ13N68wqrKSeScUKdA==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-ia32-msvc@4.13.0:
+    resolution: {integrity: sha512-P5/MqLdLSlqxbeuJ3YDeX37srC8mCflSyTrUsgbU1c/U9j6l2g2GiIdYaGD9QjdMQPMSgYm7hgg0551wHyIluw==}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-x64-msvc@4.13.0:
+    resolution: {integrity: sha512-UKXUQNbO3DOhzLRwHSpa0HnhhCgNODvfoPWv2FCXme8N/ANFfhIPMGuOT+QuKd16+B5yxZ0HdpNlqPvTMS1qfw==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@rushstack/node-core-library@3.55.2:
     resolution: {integrity: sha512-SaLe/x/Q/uBVdNFK5V1xXvsVps0y7h1sN7aSJllQyFbugyOaxhNRF25bwEDnicARNEjJw0pk0lYnJQ9Kr6ev0A==}
     peerDependencies:
@@ -5825,6 +6136,50 @@ packages:
       rollup: 3.20.2
       typescript: 5.2.2
       vite: 4.4.10
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@storybook/builder-vite@7.0.2(typescript@5.2.2)(vite@4.4.9):
+    resolution: {integrity: sha512-G6CD2Gf2zwzRslvNvqgz4FeADVEA9XA4Mw6+NM6Twc+Wy/Ah482dvHS9ApSgirtGyBKjOfdHn1xQT4Z+kzbJnw==}
+    peerDependencies:
+      '@preact/preset-vite': '*'
+      '@storybook/mdx1-csf': '>=1.0.0-next.1'
+      typescript: '>= 4.3.x'
+      vite: ^3.0.0 || ^4.0.0
+      vite-plugin-glimmerx: '*'
+    peerDependenciesMeta:
+      '@preact/preset-vite':
+        optional: true
+      '@storybook/mdx1-csf':
+        optional: true
+      typescript:
+        optional: true
+      vite-plugin-glimmerx:
+        optional: true
+    dependencies:
+      '@storybook/channel-postmessage': 7.0.2
+      '@storybook/channel-websocket': 7.0.2
+      '@storybook/client-logger': 7.0.2
+      '@storybook/core-common': 7.0.2
+      '@storybook/csf-plugin': 7.0.2
+      '@storybook/mdx2-csf': 1.0.0
+      '@storybook/node-logger': 7.0.2
+      '@storybook/preview': 7.0.2
+      '@storybook/preview-api': 7.0.2
+      '@storybook/types': 7.0.2
+      browser-assert: 1.2.1
+      es-module-lexer: 0.9.3
+      express: 4.18.2
+      fs-extra: 11.1.1
+      glob: 8.1.0
+      glob-promise: 6.0.2(glob@8.1.0)
+      magic-string: 0.27.0
+      remark-external-links: 8.0.0
+      remark-slug: 6.1.0
+      rollup: 3.20.2
+      typescript: 5.2.2
+      vite: 4.4.9(@types/node@18.15.11)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6976,7 +7331,7 @@ packages:
       file-system-cache: 2.3.0
     dev: true
 
-  /@storybook/vue3-vite@7.0.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(vite@4.4.10)(vue@3.4.21):
+  /@storybook/vue3-vite@7.0.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(vite@4.4.9)(vue@3.4.21):
     resolution: {integrity: sha512-lmxnHA9wHkgbNq+oW6dVnXbe9QOFjOz4Ejkl1AAjjg0blJ+VGautVa3mSeYM99szx5EigSfQjFAkv/TAJVC80Q==}
     engines: {node: ^14.18 || >=16}
     peerDependencies:
@@ -6984,14 +7339,14 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
       vite: ^3.0.0 || ^4.0.0
     dependencies:
-      '@storybook/builder-vite': 7.0.2(typescript@5.2.2)(vite@4.4.10)
+      '@storybook/builder-vite': 7.0.2(typescript@5.2.2)(vite@4.4.9)
       '@storybook/core-server': 7.0.2
       '@storybook/vue3': 7.0.2(vue@3.4.21)
-      '@vitejs/plugin-vue': 4.1.0(vite@4.4.10)(vue@3.4.21)
+      '@vitejs/plugin-vue': 4.1.0(vite@4.4.9)(vue@3.4.21)
       magic-string: 0.27.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      vite: 4.4.10
+      vite: 4.4.9(@types/node@18.15.11)
       vue-docgen-api: 4.64.1(vue@3.4.21)
     transitivePeerDependencies:
       - '@preact/preset-vite'
@@ -7262,6 +7617,10 @@ packages:
 
   /@types/estree@1.0.0:
     resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
+    dev: true
+
+  /@types/estree@1.0.5:
+    resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
     dev: true
 
   /@types/express-serve-static-core@4.17.33:
@@ -7928,14 +8287,36 @@ packages:
       - supports-color
     dev: true
 
-  /@vitejs/plugin-vue@4.1.0(vite@4.4.10)(vue@3.4.21):
+  /@vitejs/plugin-vue@4.1.0(vite@4.4.9)(vue@3.4.21):
     resolution: {integrity: sha512-++9JOAFdcXI3lyer9UKUV4rfoQ3T1RN8yDqoCLar86s0xQct5yblxAE+yWgRnU5/0FOlVCpTZpYSBV/bGWrSrQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: ^4.0.0
       vue: ^3.2.25
     dependencies:
-      vite: 4.4.10
+      vite: 4.4.9(@types/node@18.15.11)
+      vue: 3.4.21(typescript@5.2.2)
+    dev: true
+
+  /@vitejs/plugin-vue@5.0.4(vite@4.4.9)(vue@3.4.21):
+    resolution: {integrity: sha512-WS3hevEszI6CEVEx28F8RjTX97k3KsrcY6kvTg7+Whm5y3oYvcqzVeGCU3hxSAn4uY2CLCkeokkGKpoctccilQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    peerDependencies:
+      vite: ^5.0.0
+      vue: ^3.2.25
+    dependencies:
+      vite: 4.4.9(@types/node@18.15.11)
+      vue: 3.4.21(typescript@5.2.2)
+    dev: true
+
+  /@vitejs/plugin-vue@5.0.4(vite@5.2.6)(vue@3.4.21):
+    resolution: {integrity: sha512-WS3hevEszI6CEVEx28F8RjTX97k3KsrcY6kvTg7+Whm5y3oYvcqzVeGCU3hxSAn4uY2CLCkeokkGKpoctccilQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    peerDependencies:
+      vite: ^5.0.0
+      vue: ^3.2.25
+    dependencies:
+      vite: 5.2.6
       vue: 3.4.21(typescript@5.2.2)
     dev: true
 
@@ -7970,22 +8351,22 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
-  /@volar/language-core@2.1.5:
-    resolution: {integrity: sha512-u1OHmVkCFsJqNdaM2GKuMhE67TxcEnOqJNF+VtYv2Ji8DnrUaF4FAFSNxY+MRGICl+873CsSJVKas9TQtW14LA==}
+  /@volar/language-core@1.11.1:
+    resolution: {integrity: sha512-dOcNn3i9GgZAcJt43wuaEykSluAuOkQgzni1cuxLxTV0nJKanQztp7FxyswdRILaKH+P2XZMPRp2S4MV/pElCw==}
     dependencies:
-      '@volar/source-map': 2.1.5
+      '@volar/source-map': 1.11.1
     dev: true
 
-  /@volar/source-map@2.1.5:
-    resolution: {integrity: sha512-GIkAM6fHgDcTXcdH4i10fAiAZzO0HLIer8/pt3oZ9A0n7n4R5d1b2F8Xxzh/pgmgNoL+SrHX3MFxs35CKgfmtA==}
+  /@volar/source-map@1.11.1:
+    resolution: {integrity: sha512-hJnOnwZ4+WT5iupLRnuzbULZ42L7BWWPMmruzwtLhJfpDVoZLjNBxHDi2sY2bgZXCKlpU5XcsMFoYrsQmPhfZg==}
     dependencies:
-      muggle-string: 0.4.1
+      muggle-string: 0.3.1
     dev: true
 
-  /@volar/typescript@2.1.5:
-    resolution: {integrity: sha512-zo9a3NrNMSkufIvHuExDGTfYv+zO7C5p2wg8fyP7vcqF/Qo0ztjb0ZfOgq/A85EO/MBc1Kj2Iu7PaOBtP++NMw==}
+  /@volar/typescript@1.11.1:
+    resolution: {integrity: sha512-iU+t2mas/4lYierSnoFOeRFQUhAEMgsFuQxoxvwn5EdQopw43j+J27a4lt9LMInx1gLJBC6qL14WYGlgymaSMQ==}
     dependencies:
-      '@volar/language-core': 2.1.5
+      '@volar/language-core': 1.11.1
       path-browserify: 1.0.1
     dev: true
 
@@ -8045,19 +8426,21 @@ packages:
   /@vue/devtools-api@6.6.1:
     resolution: {integrity: sha512-LgPscpE3Vs0x96PzSSB4IGVSZXZBZHpfxs+ZA1d+VEPwHdOXowy/Y2CsvCAIFrf+ssVU1pD1jidj505EpUnfbA==}
 
-  /@vue/language-core@2.0.7(typescript@5.2.2):
-    resolution: {integrity: sha512-Vh1yZX3XmYjn9yYLkjU8DN6L0ceBtEcapqiyclHne8guG84IaTzqtvizZB1Yfxm3h6m7EIvjerLO5fvOZO6IIQ==}
+  /@vue/language-core@1.8.27(typescript@5.2.2):
+    resolution: {integrity: sha512-L8Kc27VdQserNaCUNiSFdDl9LWT24ly8Hpwf1ECy3aFb9m6bDhBGQYOujDm21N7EW3moKIOKEanQwe1q5BK+mA==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@volar/language-core': 2.1.5
+      '@volar/language-core': 1.11.1
+      '@volar/source-map': 1.11.1
       '@vue/compiler-dom': 3.4.21
       '@vue/shared': 3.4.21
       computeds: 0.0.1
       minimatch: 9.0.3
+      muggle-string: 0.3.1
       path-browserify: 1.0.1
       typescript: 5.2.2
       vue-template-compiler: 2.7.14
@@ -11078,6 +11461,37 @@ packages:
       '@esbuild/win32-arm64': 0.18.20
       '@esbuild/win32-ia32': 0.18.20
       '@esbuild/win32-x64': 0.18.20
+    dev: true
+
+  /esbuild@0.20.2:
+    resolution: {integrity: sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.20.2
+      '@esbuild/android-arm': 0.20.2
+      '@esbuild/android-arm64': 0.20.2
+      '@esbuild/android-x64': 0.20.2
+      '@esbuild/darwin-arm64': 0.20.2
+      '@esbuild/darwin-x64': 0.20.2
+      '@esbuild/freebsd-arm64': 0.20.2
+      '@esbuild/freebsd-x64': 0.20.2
+      '@esbuild/linux-arm': 0.20.2
+      '@esbuild/linux-arm64': 0.20.2
+      '@esbuild/linux-ia32': 0.20.2
+      '@esbuild/linux-loong64': 0.20.2
+      '@esbuild/linux-mips64el': 0.20.2
+      '@esbuild/linux-ppc64': 0.20.2
+      '@esbuild/linux-riscv64': 0.20.2
+      '@esbuild/linux-s390x': 0.20.2
+      '@esbuild/linux-x64': 0.20.2
+      '@esbuild/netbsd-x64': 0.20.2
+      '@esbuild/openbsd-x64': 0.20.2
+      '@esbuild/sunos-x64': 0.20.2
+      '@esbuild/win32-arm64': 0.20.2
+      '@esbuild/win32-ia32': 0.20.2
+      '@esbuild/win32-x64': 0.20.2
     dev: true
 
   /escalade@3.1.1:
@@ -15373,8 +15787,8 @@ packages:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
     dev: true
 
-  /muggle-string@0.4.1:
-    resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
+  /muggle-string@0.3.1:
+    resolution: {integrity: sha512-ckmWDJjphvd/FvZawgygcUeQCxzvohjFO5RxTjj4eq8kw359gFF3E1brjfI+viLMxss5JrHTDRHZvu2/tuy0Qg==}
     dev: true
 
   /mustache@4.2.0:
@@ -17645,6 +18059,29 @@ packages:
       fsevents: 2.3.3
     dev: true
 
+  /rollup@4.13.0:
+    resolution: {integrity: sha512-3YegKemjoQnYKmsBlOHfMLVPPA5xLkQ8MHLLSw/fBrFaVkEayL51DilPpNNLq1exr98F2B1TzrV0FUlN3gWRPg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+    dependencies:
+      '@types/estree': 1.0.5
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.13.0
+      '@rollup/rollup-android-arm64': 4.13.0
+      '@rollup/rollup-darwin-arm64': 4.13.0
+      '@rollup/rollup-darwin-x64': 4.13.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.13.0
+      '@rollup/rollup-linux-arm64-gnu': 4.13.0
+      '@rollup/rollup-linux-arm64-musl': 4.13.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.13.0
+      '@rollup/rollup-linux-x64-gnu': 4.13.0
+      '@rollup/rollup-linux-x64-musl': 4.13.0
+      '@rollup/rollup-win32-arm64-msvc': 4.13.0
+      '@rollup/rollup-win32-ia32-msvc': 4.13.0
+      '@rollup/rollup-win32-x64-msvc': 4.13.0
+      fsevents: 2.3.3
+    dev: true
+
   /rrweb-cssom@0.6.0:
     resolution: {integrity: sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==}
     dev: true
@@ -19765,6 +20202,41 @@ packages:
       fsevents: 2.3.3
     dev: true
 
+  /vite@5.2.6:
+    resolution: {integrity: sha512-FPtnxFlSIKYjZ2eosBQamz4CbyrTizbZ3hnGJlh/wMtCrlp1Hah6AzBLjGI5I2urTfNnpovpHdrL6YRuBOPnCA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      esbuild: 0.20.2
+      postcss: 8.4.38
+      rollup: 4.13.0
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
   /vitest@0.29.8(jsdom@21.1.1)(playwright@1.32.1):
     resolution: {integrity: sha512-JIAVi2GK5cvA6awGpH0HvH/gEG9PZ0a/WoxdiV3PmqK+3CjQMf8c+J/Vhv4mdZ2nRyXFw66sAg6qz7VNkaHfDQ==}
     engines: {node: '>=v14.16.0'}
@@ -19900,15 +20372,15 @@ packages:
       he: 1.2.0
     dev: true
 
-  /vue-tsc@2.0.7(typescript@5.2.2):
-    resolution: {integrity: sha512-LYa0nInkfcDBB7y8jQ9FQ4riJTRNTdh98zK/hzt4gEpBZQmf30dPhP+odzCa+cedGz6B/guvJEd0BavZaRptjg==}
+  /vue-tsc@1.8.27(typescript@5.2.2):
+    resolution: {integrity: sha512-WesKCAZCRAbmmhuGl3+VrdWItEvfoFIPXOvUJkjULi+x+6G/Dy69yO3TBRJDr9eUlmsNAwVmxsNZxvHKzbkKdg==}
     hasBin: true
     peerDependencies:
       typescript: '*'
     dependencies:
-      '@volar/typescript': 2.1.5
-      '@vue/language-core': 2.0.7(typescript@5.2.2)
-      semver: 7.5.4
+      '@volar/typescript': 1.11.1
+      '@vue/language-core': 1.8.27(typescript@5.2.2)
+      semver: 7.6.0
       typescript: 5.2.2
     dev: true
 


### PR DESCRIPTION
# タスク

resolve: #1252

### 備考
https://blog.vuejs.org/posts/vue-3-4
> To fully leverage new features in 3.4, it is recommended to also update the following dependencies when upgrading to 3.4:
> Volar / vue-tsc@^1.8.27 (required)
> @vitejs/plugin-vue@^5.0.0 (if using Vite)
> nuxt@^3.9.0 (if using Nuxt)
> vue-loader@^17.4.0 (if using webpack or vue-cli)

<!-- reviewerにオーナーを追加してください-->
