### PR TITLE
FormControlにborderLeftプロパティと、borderColorプロパティを追加

### DIFF
--- a/.changeset/sour-flies-smoke.md
+++ b/.changeset/sour-flies-smoke.md
@@ -1,0 +1,7 @@
+---
+"@wizleap-inc/wiz-ui-react": minor
+"@wizleap-inc/wiz-ui-next": minor
+"@wizleap-inc/wiz-ui-styles": minor
+---
+
+Added borderLeft and borderColor props to FormControl.

--- a/packages/styles/customs/form-control.css.ts
+++ b/packages/styles/customs/form-control.css.ts
@@ -4,9 +4,12 @@ import { THEME } from "@wizleap-inc/wiz-ui-constants";
 /**
  * borderColorStyleと併用する前提のためborderColorは含まない
  */
-export const textBorderLeftStyle = style({
+export const borderLeftStyle = style({
   borderLeftWidth: "3px",
   borderLeftStyle: "solid",
   paddingLeft: THEME.spacing.xs,
+});
+
+export const borderLeftTextStyle = style({
   lineHeight: "140%",
 });

--- a/packages/styles/customs/form-control.css.ts
+++ b/packages/styles/customs/form-control.css.ts
@@ -1,0 +1,12 @@
+import { style } from "@vanilla-extract/css";
+import { THEME } from "@wizleap-inc/wiz-ui-constants";
+
+/**
+ * borderColorStyleと併用する前提のためborderColorは含まない
+ */
+export const textBorderLeftStyle = style({
+  borderLeftWidth: "3px",
+  borderLeftStyle: "solid",
+  paddingLeft: THEME.spacing.xs,
+  lineHeight: "140%",
+});

--- a/packages/wiz-ui-next/src/components/custom/form/control.stories.ts
+++ b/packages/wiz-ui-next/src/components/custom/form/control.stories.ts
@@ -1,4 +1,5 @@
 import { Meta, StoryFn } from "@storybook/vue3";
+import { ColorKeys, COLOR_MAP_ACCESSORS } from "@wizleap-inc/wiz-ui-constants";
 import { ref } from "vue";
 
 import { WizTextInput } from "@/components";
@@ -23,6 +24,11 @@ export default {
     direction: {
       control: { type: "select", options: ["horizontal", "vertical"] },
     },
+    borderLeft: { control: { type: "boolean" } },
+    borderColor: {
+      control: { type: "select" },
+      options: COLOR_MAP_ACCESSORS,
+    },
   },
 } as Meta<typeof WizFormControl>;
 
@@ -44,6 +50,8 @@ interface Options {
   required: boolean;
   error: string;
   direction: "horizontal" | "vertical";
+  borderLeft: boolean;
+  borderColor: ColorKeys;
 }
 
 const CODE_TEMPLATE = ({
@@ -51,13 +59,17 @@ const CODE_TEMPLATE = ({
   required,
   error,
   direction,
+  borderLeft,
+  borderColor,
 }: Partial<Options>) => `
 <template>
   <WizFormControl${
     (label ? ` label="${label}"` : "") +
     (required ? ` required` : "") +
     (error ? ` error="${error}"` : "") +
-    (direction ? ` direction="${direction}"` : "")
+    (direction ? ` direction="${direction}"` : "") +
+    (borderLeft ? ` border-left` : "") +
+    (borderColor ? ` border-color="${borderColor}"` : "")
   }>
     <WizTextInput v-model="input" name="input" placeholder="入力してください" />
   </WizFormControl>
@@ -164,6 +176,28 @@ Error.parameters = {
       code: CODE_TEMPLATE({
         label: "Label",
         error: "空白にはできません",
+      }),
+    },
+  },
+};
+
+export const BorderLeft = Template.bind({});
+BorderLeft.args = {
+  label: "Label",
+  borderLeft: true,
+  borderColor: "green.800",
+};
+BorderLeft.parameters = {
+  docs: {
+    description: {
+      story:
+        "borderLeft を指定すると左にラインが表示され、borderColor で色を変更できます。",
+    },
+    source: {
+      code: CODE_TEMPLATE({
+        label: "Label",
+        borderLeft: true,
+        borderColor: "green.800",
       }),
     },
   },

--- a/packages/wiz-ui-next/src/components/custom/form/control.vue
+++ b/packages/wiz-ui-next/src/components/custom/form/control.vue
@@ -10,12 +10,16 @@
       :align="direction === 'horizontal' ? 'center' : undefined"
       :wrap="false"
     >
-      <WizHStack :width="labelWidth" align="center" gap="xs2" py="xs2">
+      <WizHStack :width="labelWidth" align="center" gap="xs" py="xs2">
         <WizText
           as="label"
           :htmlFor="htmlFor"
           :color="labelColor"
           :font-size="labelFontSize"
+          :bold="borderLeft"
+          :class="[
+            borderLeft && [textBorderLeftStyle, borderColorStyle[borderColor]],
+          ]"
         >
           {{ label }}
         </WizText>
@@ -35,7 +39,9 @@
 </template>
 
 <script setup lang="ts">
-import { THEME } from "@wizleap-inc/wiz-ui-constants";
+import { ColorKeys, THEME } from "@wizleap-inc/wiz-ui-constants";
+import { borderColorStyle } from "@wizleap-inc/wiz-ui-styles/commons/border-color.css";
+import { textBorderLeftStyle } from "@wizleap-inc/wiz-ui-styles/customs/form-control.css";
 import { PropType, computed, inject, onMounted, provide, watch } from "vue";
 
 import {
@@ -71,6 +77,14 @@ const props = defineProps({
   direction: {
     type: String as PropType<"horizontal" | "vertical">,
     default: "horizontal",
+  },
+  borderLeft: {
+    type: Boolean,
+    default: false,
+  },
+  borderColor: {
+    type: String as PropType<ColorKeys>,
+    default: "green.800",
   },
 });
 

--- a/packages/wiz-ui-next/src/components/custom/form/control.vue
+++ b/packages/wiz-ui-next/src/components/custom/form/control.vue
@@ -10,16 +10,22 @@
       :align="direction === 'horizontal' ? 'center' : undefined"
       :wrap="false"
     >
-      <WizHStack :width="labelWidth" align="center" gap="xs" py="xs2">
+      <WizHStack
+        :width="labelWidth"
+        align="center"
+        gap="xs"
+        my="xs2"
+        :class="[
+          borderLeft && [borderLeftStyle, borderColorStyle[borderColor]],
+        ]"
+      >
         <WizText
           as="label"
           :htmlFor="htmlFor"
           :color="labelColor"
           :font-size="labelFontSize"
           :bold="borderLeft"
-          :class="[
-            borderLeft && [textBorderLeftStyle, borderColorStyle[borderColor]],
-          ]"
+          :class="[borderLeft && borderLeftTextStyle]"
         >
           {{ label }}
         </WizText>
@@ -41,7 +47,10 @@
 <script setup lang="ts">
 import { ColorKeys, THEME } from "@wizleap-inc/wiz-ui-constants";
 import { borderColorStyle } from "@wizleap-inc/wiz-ui-styles/commons/border-color.css";
-import { textBorderLeftStyle } from "@wizleap-inc/wiz-ui-styles/customs/form-control.css";
+import {
+  borderLeftStyle,
+  borderLeftTextStyle,
+} from "@wizleap-inc/wiz-ui-styles/customs/form-control.css";
 import { PropType, computed, inject, onMounted, provide, watch } from "vue";
 
 import {

--- a/packages/wiz-ui-next/src/components/custom/form/group.stories.ts
+++ b/packages/wiz-ui-next/src/components/custom/form/group.stories.ts
@@ -126,7 +126,7 @@ Default.parameters = {
 
 export const LabelWidth = Template.bind({});
 LabelWidth.args = {
-  labelWidth: "6rem",
+  labelWidth: "6.25rem",
 };
 LabelWidth.parameters = {
   docs: {

--- a/packages/wiz-ui-react/src/components/custom/form/components/form-control.tsx
+++ b/packages/wiz-ui-react/src/components/custom/form/components/form-control.tsx
@@ -74,7 +74,9 @@ const FormControl: FC<Props> = ({
               color={labelColor}
               fontSize={labelFontSize}
               bold={borderLeft}
-              className={styles.borderLeftTextStyle}
+              className={clsx({
+                [styles.borderLeftTextStyle]: borderLeft,
+              })}
             >
               {label}
             </WizText>

--- a/packages/wiz-ui-react/src/components/custom/form/components/form-control.tsx
+++ b/packages/wiz-ui-react/src/components/custom/form/components/form-control.tsx
@@ -1,4 +1,7 @@
-import { ComponentName, THEME } from "@wizleap-inc/wiz-ui-constants";
+import { ComponentName, THEME, ColorKeys } from "@wizleap-inc/wiz-ui-constants";
+import { borderColorStyle } from "@wizleap-inc/wiz-ui-styles/commons/border-color.css";
+import * as styles from "@wizleap-inc/wiz-ui-styles/customs/form-control.css";
+import clsx from "clsx";
 import { FC, ReactNode, useContext, useMemo } from "react";
 
 import { WizHStack, WizStack, WizTag, WizText, WizVStack } from "@/components";
@@ -14,6 +17,8 @@ type Props = BaseProps & {
   error?: string;
   children: ReactNode;
   direction?: "horizontal" | "vertical";
+  borderLeft?: boolean;
+  borderColor?: ColorKeys;
 };
 
 const FormControl: FC<Props> = ({
@@ -25,6 +30,8 @@ const FormControl: FC<Props> = ({
   error,
   direction = "horizontal",
   children,
+  borderLeft = false,
+  borderColor = "green.800",
 }) => {
   const {
     labelWidth = "8rem",
@@ -57,6 +64,11 @@ const FormControl: FC<Props> = ({
               htmlFor={htmlFor}
               color={labelColor}
               fontSize={labelFontSize}
+              bold={borderLeft}
+              className={clsx({
+                [styles.textBorderLeftStyle]: borderLeft,
+                [borderColorStyle[borderColor]]: borderLeft,
+              })}
             >
               {label}
             </WizText>

--- a/packages/wiz-ui-react/src/components/custom/form/components/form-control.tsx
+++ b/packages/wiz-ui-react/src/components/custom/form/components/form-control.tsx
@@ -58,7 +58,7 @@ const FormControl: FC<Props> = ({
           nowrap
           align={direction === "horizontal" ? "center" : undefined}
         >
-          <WizHStack width={labelWidth} align="center" gap="xs2" py="xs2">
+          <WizHStack width={labelWidth} align="center" gap="xs" py="xs2">
             <WizText
               as="label"
               htmlFor={htmlFor}

--- a/packages/wiz-ui-react/src/components/custom/form/components/form-control.tsx
+++ b/packages/wiz-ui-react/src/components/custom/form/components/form-control.tsx
@@ -58,17 +58,23 @@ const FormControl: FC<Props> = ({
           nowrap
           align={direction === "horizontal" ? "center" : undefined}
         >
-          <WizHStack width={labelWidth} align="center" gap="xs" py="xs2">
+          <WizHStack
+            width={labelWidth}
+            align="center"
+            gap="xs"
+            my="xs2"
+            className={clsx({
+              [styles.borderLeftStyle]: borderLeft,
+              [borderColorStyle[borderColor]]: borderLeft,
+            })}
+          >
             <WizText
               as="label"
               htmlFor={htmlFor}
               color={labelColor}
               fontSize={labelFontSize}
               bold={borderLeft}
-              className={clsx({
-                [styles.textBorderLeftStyle]: borderLeft,
-                [borderColorStyle[borderColor]]: borderLeft,
-              })}
+              className={styles.borderLeftTextStyle}
             >
               {label}
             </WizText>

--- a/packages/wiz-ui-react/src/components/custom/form/stories/form-control.stories.tsx
+++ b/packages/wiz-ui-react/src/components/custom/form/stories/form-control.stories.tsx
@@ -75,3 +75,19 @@ export const Error: Story = {
     },
   },
 };
+
+export const BorderLeft: Story = {
+  args: {
+    label: "Label",
+    borderLeft: true,
+    children: <WizTextInput placeholder="入力してください" />,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "borderLeftを指定すると、labelの左側にボーダーが表示されます。`borderColor` で色を指定できます。default は `green.800` です。",
+      },
+    },
+  },
+};

--- a/packages/wiz-ui-react/src/components/custom/form/stories/form-group.stories.tsx
+++ b/packages/wiz-ui-react/src/components/custom/form/stories/form-group.stories.tsx
@@ -49,7 +49,7 @@ export const Default: Story = {
 export const LabelWidth: Story = {
   ...Template,
   args: {
-    labelWidth: "6rem",
+    labelWidth: "6.25rem",
   },
   parameters: {
     docs: {


### PR DESCRIPTION
# タスク

resolve: #1443

## やったこと
1. borderLeftプロパティと、borderColorプロパティの追加を行いました。
2. Figmaのスタイルに準拠するため親要素gapをxs2からxsに変更しました。(BorderとTextの幅と揃える）
認)
![スクリーンショット 2025-03-25 12 14 39](https://github.com/user-attachments/assets/733a59ea-7535-463f-8639-e7eccbe1b19d)

## やらないこと
- h4タグの対応

## 特にレビューしてほしい箇所
- .changeset/sour-flies-smoke.md
- font-weightはコンポーネントの状態がわかりやすくなるようにWizTextのboldプロパティを用いましたが、lineHeightに関してはFontSizeによって柔軟に変更したいので `%`で指定したいと考えてlineHeightプロパティは使用しておりません。

