### PR TITLE
FormControl 内のラベルタグの位置を指定できるようにする

### DIFF
--- a/.changeset/modern-kiwis-thank.md
+++ b/.changeset/modern-kiwis-thank.md
@@ -1,0 +1,6 @@
+---
+"@wizleap-inc/wiz-ui-react": minor
+"@wizleap-inc/wiz-ui-next": minor
+---
+
+FormControl 内のラベルタグの位置を指定できるようにする

--- a/packages/wiz-ui-next/src/components/custom/form/control.stories.ts
+++ b/packages/wiz-ui-next/src/components/custom/form/control.stories.ts
@@ -22,12 +22,17 @@ export default {
       control: { type: "text" },
     },
     direction: {
-      control: { type: "select", options: ["horizontal", "vertical"] },
+      control: { type: "select" },
+      options: ["horizontal", "vertical"],
     },
     borderLeft: { control: { type: "boolean" } },
     borderColor: {
       control: { type: "select" },
       options: COLOR_MAP_ACCESSORS,
+    },
+    labelTagPosition: {
+      control: { type: "select" },
+      options: ["right", "left"],
     },
   },
 } as Meta<typeof WizFormControl>;

--- a/packages/wiz-ui-next/src/components/custom/form/control.stories.ts
+++ b/packages/wiz-ui-next/src/components/custom/form/control.stories.ts
@@ -57,6 +57,7 @@ interface Options {
   direction: "horizontal" | "vertical";
   borderLeft: boolean;
   borderColor: ColorKeys;
+  LabelTagPosition: "right" | "left";
 }
 
 const CODE_TEMPLATE = ({
@@ -66,6 +67,7 @@ const CODE_TEMPLATE = ({
   direction,
   borderLeft,
   borderColor,
+  LabelTagPosition,
 }: Partial<Options>) => `
 <template>
   <WizFormControl${
@@ -74,7 +76,8 @@ const CODE_TEMPLATE = ({
     (error ? ` error="${error}"` : "") +
     (direction ? ` direction="${direction}"` : "") +
     (borderLeft ? ` border-left` : "") +
-    (borderColor ? ` border-color="${borderColor}"` : "")
+    (borderColor ? ` border-color="${borderColor}"` : "") +
+    (LabelTagPosition ? ` label-tag-position="${LabelTagPosition}"` : "")
   }>
     <WizTextInput v-model="input" name="input" placeholder="入力してください" />
   </WizFormControl>
@@ -197,6 +200,28 @@ BorderLeft.parameters = {
     description: {
       story:
         "borderLeft を指定すると左にラインが表示され、borderColor で色を変更できます。",
+    },
+    source: {
+      code: CODE_TEMPLATE({
+        label: "Label",
+        borderLeft: true,
+        borderColor: "green.800",
+      }),
+    },
+  },
+};
+
+export const LabelTagPosition = Template.bind({});
+LabelTagPosition.args = {
+  label: "Label",
+  required: true,
+  labelTagPosition: "left",
+};
+LabelTagPosition.parameters = {
+  docs: {
+    description: {
+      story:
+        "labelTagPositionを指定すると、labelのTagの位置を変更できます。`left` または `right` を指定できます。default は `right` です。",
     },
     source: {
       code: CODE_TEMPLATE({

--- a/packages/wiz-ui-next/src/components/custom/form/control.vue
+++ b/packages/wiz-ui-next/src/components/custom/form/control.vue
@@ -13,6 +13,8 @@
       <WizHStack
         :width="labelWidth"
         align="center"
+        :reverse="labelTagPosition === 'left'"
+        :justify="labelTagPosition === 'left' ? 'end' : 'start'"
         gap="xs"
         my="xs2"
         :class="[
@@ -95,6 +97,10 @@ const props = defineProps({
     type: String as PropType<ColorKeys>,
     default: "green.800",
   },
+  labelTagPosition: {
+    type: String as PropType<"left" | "right">,
+    required: false,
+  },
 });
 
 // Form Group
@@ -102,6 +108,9 @@ const fromGroup = inject(formGroupKey);
 const labelWidth = computed(() => fromGroup?.labelWidth.value || "8rem");
 const labelColor = computed(() => fromGroup?.labelColor.value || "gray.900");
 const labelFontSize = computed(() => fromGroup?.labelFontSize.value || "md");
+const labelTagPosition = computed(
+  () => props.labelTagPosition || fromGroup?.labelTagPosition.value || "right"
+);
 
 const errorLeft = computed(() =>
   props.direction === "horizontal" ? labelWidth.value : "0"

--- a/packages/wiz-ui-next/src/components/custom/form/group.stories.ts
+++ b/packages/wiz-ui-next/src/components/custom/form/group.stories.ts
@@ -50,6 +50,10 @@ export default {
       control: { type: "select" },
       options: FONT_SIZE_ACCESSORS,
     },
+    labelTagPosition: {
+      control: { type: "select" },
+      options: ["left", "right"],
+    },
   },
 } as Meta<typeof WizFormGroup>;
 
@@ -77,6 +81,7 @@ interface Options {
   gap: string;
   labelColor: ColorKeys;
   labelFontSize: FontSizeKeys;
+  labelTagPosition: "right" | "left";
 }
 
 const CODE_TEMPLATE = ({
@@ -84,13 +89,15 @@ const CODE_TEMPLATE = ({
   gap,
   labelColor,
   labelFontSize,
+  labelTagPosition,
 }: Partial<Options>) => `
 <template>
   <WizFormGroup${
     (labelWidth ? ` label-width="${labelWidth}"` : "") +
     (gap ? ` gap="${gap}"` : "") +
     (labelColor ? ` label-color="${labelColor}"` : "") +
-    (labelFontSize ? ` label-font-size="${labelFontSize}"` : "")
+    (labelFontSize ? ` label-font-size="${labelFontSize}"` : "") +
+    (labelTagPosition ? ` label-tag-position="${labelTagPosition}"` : "")
   }>
     <WizFormControl label="Label1">
       <WizTextInput v-model="input" name="input" />
@@ -184,6 +191,22 @@ LabelFontSize.parameters = {
     },
     source: {
       code: CODE_TEMPLATE({ labelFontSize: "xl3" }),
+    },
+  },
+};
+
+export const LabelTagPosition = Template.bind({});
+LabelTagPosition.args = {
+  labelTagPosition: "left",
+};
+LabelTagPosition.parameters = {
+  docs: {
+    description: {
+      story:
+        "slotに持っている**FormControl**の各要素のラベルサイズを一括指定できます。",
+    },
+    source: {
+      code: CODE_TEMPLATE({ labelTagPosition: "left" }),
     },
   },
 };

--- a/packages/wiz-ui-next/src/components/custom/form/group.stories.ts
+++ b/packages/wiz-ui-next/src/components/custom/form/group.stories.ts
@@ -203,7 +203,7 @@ LabelTagPosition.parameters = {
   docs: {
     description: {
       story:
-        "slotに持っている**FormControl**の各要素のラベルサイズを一括指定できます。",
+        "slotに持っている**FormControl**の各要素のラベルタグの位置を一括指定できます。ただし、各**FormControl**に個別でlabelTagPositionが指定されている場合は、そちらがの設定が優先されます。",
     },
     source: {
       code: CODE_TEMPLATE({ labelTagPosition: "left" }),

--- a/packages/wiz-ui-next/src/components/custom/form/group.vue
+++ b/packages/wiz-ui-next/src/components/custom/form/group.vue
@@ -52,8 +52,6 @@ watch(props, (p) => p.labelColor && setLabelColor(p.labelColor));
 onMounted(() => props.labelColor && setLabelColor(props.labelColor));
 watch(props, (p) => p.labelFontSize && setLabelFontSize(p.labelFontSize));
 onMounted(() => props.labelFontSize && setLabelFontSize(props.labelFontSize));
-watch(props, (p) => p.labelFontSize && setLabelFontSize(p.labelFontSize));
-onMounted(() => props.labelFontSize && setLabelFontSize(props.labelFontSize));
 watch(
   props,
   (p) => p.labelTagPosition && setLabelTagPosition(p.labelTagPosition)

--- a/packages/wiz-ui-next/src/components/custom/form/group.vue
+++ b/packages/wiz-ui-next/src/components/custom/form/group.vue
@@ -35,16 +35,30 @@ const props = defineProps({
     type: String as PropType<FontSizeKeys>,
     required: false,
   },
+  labelTagPosition: {
+    type: String as PropType<"right" | "left">,
+    required: false,
+  },
 });
 
 // Form Group
 const provider = useFormGroupProvider();
 provide(formGroupKey, provider);
-const { setLabelWidth, setLabelColor, setLabelFontSize } = provider;
+const { setLabelWidth, setLabelColor, setLabelFontSize, setLabelTagPosition } =
+  provider;
 watch(props, (p) => p.labelWidth && setLabelWidth(p.labelWidth));
 onMounted(() => props.labelWidth && setLabelWidth(props.labelWidth));
 watch(props, (p) => p.labelColor && setLabelColor(p.labelColor));
 onMounted(() => props.labelColor && setLabelColor(props.labelColor));
 watch(props, (p) => p.labelFontSize && setLabelFontSize(p.labelFontSize));
 onMounted(() => props.labelFontSize && setLabelFontSize(props.labelFontSize));
+watch(props, (p) => p.labelFontSize && setLabelFontSize(p.labelFontSize));
+onMounted(() => props.labelFontSize && setLabelFontSize(props.labelFontSize));
+watch(
+  props,
+  (p) => p.labelTagPosition && setLabelTagPosition(p.labelTagPosition)
+);
+onMounted(
+  () => props.labelTagPosition && setLabelTagPosition(props.labelTagPosition)
+);
 </script>

--- a/packages/wiz-ui-next/src/hooks/use-form-group-provider.ts
+++ b/packages/wiz-ui-next/src/hooks/use-form-group-provider.ts
@@ -17,6 +17,11 @@ export const useFormGroupProvider = () => {
     labelFontSize.value = value;
   };
 
+  const labelTagPosition = ref<"right" | "left">("right");
+  const setLabelTagPosition = (value: "right" | "left") => {
+    labelTagPosition.value = value;
+  };
+
   return {
     labelWidth: readonly(labelWidth),
     setLabelWidth,
@@ -24,6 +29,8 @@ export const useFormGroupProvider = () => {
     setLabelColor,
     labelFontSize: readonly(labelFontSize),
     setLabelFontSize,
+    labelTagPosition: readonly(labelTagPosition),
+    setLabelTagPosition,
   };
 };
 

--- a/packages/wiz-ui-react/src/components/custom/form/components/form-control.tsx
+++ b/packages/wiz-ui-react/src/components/custom/form/components/form-control.tsx
@@ -19,6 +19,7 @@ type Props = BaseProps & {
   direction?: "horizontal" | "vertical";
   borderLeft?: boolean;
   borderColor?: ColorKeys;
+  labelTagPosition?: "left" | "right";
 };
 
 const FormControl: FC<Props> = ({
@@ -32,12 +33,17 @@ const FormControl: FC<Props> = ({
   children,
   borderLeft = false,
   borderColor = "green.800",
+  labelTagPosition,
 }) => {
   const {
     labelWidth = "8rem",
     labelColor,
     labelFontSize,
+    labelTagPosition: labelTagPositionContext,
   } = useContext(FormGroupContext);
+
+  const resolvedLabelTagPosition =
+    labelTagPosition || labelTagPositionContext || "right";
 
   const errorLeft = useMemo(() => {
     return direction === "horizontal" ? labelWidth : undefined;
@@ -61,6 +67,8 @@ const FormControl: FC<Props> = ({
           <WizHStack
             width={labelWidth}
             align="center"
+            reverse={resolvedLabelTagPosition === "left"}
+            justify={resolvedLabelTagPosition === "left" ? "end" : "start"}
             gap="xs"
             my="xs2"
             className={clsx({

--- a/packages/wiz-ui-react/src/components/custom/form/components/form-group-context.ts
+++ b/packages/wiz-ui-react/src/components/custom/form/components/form-group-context.ts
@@ -5,6 +5,7 @@ type FormGroupContextType = {
   labelWidth?: string;
   labelColor?: ColorKeys;
   labelFontSize?: FontSizeKeys;
+  labelTagPosition?: "left" | "right";
 };
 
 export const FormGroupContext = createContext<FormGroupContextType>({});

--- a/packages/wiz-ui-react/src/components/custom/form/components/form-group.tsx
+++ b/packages/wiz-ui-react/src/components/custom/form/components/form-group.tsx
@@ -15,6 +15,7 @@ type Props = BaseProps & {
   labelWidth?: string;
   labelColor?: ColorKeys;
   labelFontSize?: FontSizeKeys;
+  labelTagPosition?: "left" | "right";
   gap?: SpacingKeys;
   children: ReactNode;
 };
@@ -25,6 +26,7 @@ const FormGroup: FC<Props> = ({
   labelWidth,
   labelColor = "gray.900",
   labelFontSize = "md",
+  labelTagPosition,
   gap = "md",
   children,
 }) => {
@@ -34,6 +36,7 @@ const FormGroup: FC<Props> = ({
         labelWidth,
         labelColor,
         labelFontSize,
+        labelTagPosition,
       }}
     >
       <WizVStack className={className} style={style} gap={gap}>

--- a/packages/wiz-ui-react/src/components/custom/form/stories/form-control.stories.tsx
+++ b/packages/wiz-ui-react/src/components/custom/form/stories/form-control.stories.tsx
@@ -91,3 +91,19 @@ export const BorderLeft: Story = {
     },
   },
 };
+
+export const labelTagPosition: Story = {
+  args: {
+    label: "Label",
+    labelTagPosition: "left",
+    children: <WizTextInput placeholder="入力してください" required />,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "labelTagPositionを指定すると、labelのTagの位置を変更できます。`left` または `right` を指定できます。default は `right` です。",
+      },
+    },
+  },
+};

--- a/packages/wiz-ui-react/src/components/custom/form/stories/form-control.stories.tsx
+++ b/packages/wiz-ui-react/src/components/custom/form/stories/form-control.stories.tsx
@@ -95,6 +95,7 @@ export const BorderLeft: Story = {
 export const labelTagPosition: Story = {
   args: {
     label: "Label",
+    required: true,
     labelTagPosition: "left",
     children: <WizTextInput placeholder="入力してください" required />,
   },

--- a/packages/wiz-ui-react/src/components/custom/form/stories/form-group.stories.tsx
+++ b/packages/wiz-ui-react/src/components/custom/form/stories/form-group.stories.tsx
@@ -113,7 +113,7 @@ export const labelTagPosition: Story = {
     docs: {
       description: {
         story:
-          "**FormControl**の子要素すべてに対して、ラベルタグの位置を一括で指定できます。ただし、各**FormControl**に個別でlabelTagPositionが指定されている場合は、そちらがの設定が優先されます。",
+          "子要素の**FormControl**の各要素のラベルタグの位置を一括指定できます。ただし、各**FormControl**に個別でlabelTagPositionが指定されている場合は、そちらがの設定が優先されます。",
       },
     },
   },

--- a/packages/wiz-ui-react/src/components/custom/form/stories/form-group.stories.tsx
+++ b/packages/wiz-ui-react/src/components/custom/form/stories/form-group.stories.tsx
@@ -104,6 +104,21 @@ export const LabelFontSize: Story = {
   },
 };
 
+export const labelTagPosition: Story = {
+  ...Template,
+  args: {
+    labelTagPosition: "left",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "**FormControl**の子要素すべてに対して、ラベルタグの位置を一括で指定できます。ただし、各**FormControl**に個別でlabelTagPositionが指定されている場合は、そちらがの設定が優先されます。",
+      },
+    },
+  },
+};
+
 export const AllInput: Story = AllInputStory;
 
 export const AllInputError: Story = AllInputErrorStory;


### PR DESCRIPTION
# タスク

resolve: #1446

要件にありませんでしたが、FormControl単体で使用する可能性も今後あると思ったので対応しています。
FormControlとFormGroup両方にlabelTagPositionが指定されている場合は、FormControlの設定が優先されます。