### PR TITLE
 feat(input): widthプロパティを使用可能にして、expandを非推奨にする

### DIFF
--- a/.changeset/moody-paws-double.md
+++ b/.changeset/moody-paws-double.md
@@ -1,0 +1,7 @@
+---
+"@wizleap-inc/wiz-ui-react": minor
+"@wizleap-inc/wiz-ui-next": minor
+"@wizleap-inc/wiz-ui-styles": minor
+---
+
+base/input の中で width プロパティに対応していない Component を使用可能にして、expand を非推奨にしました。

--- a/packages/styles/bases/date-range-picker.css.ts
+++ b/packages/styles/bases/date-range-picker.css.ts
@@ -40,15 +40,6 @@ export const bodyStyle = styleVariants({
   ],
 });
 
-export const widthStyle = styleVariants({
-  default: {
-    width: "20rem",
-  },
-  expanded: {
-    width: "100%",
-  },
-});
-
 export const separatorStyle = style({
   color: THEME.color.gray["500"],
 });

--- a/packages/styles/bases/password-input.css.ts
+++ b/packages/styles/bases/password-input.css.ts
@@ -1,17 +1,8 @@
-import { style, styleVariants } from "@vanilla-extract/css";
+import { style } from "@vanilla-extract/css";
 import { THEME } from "@wizleap-inc/wiz-ui-constants";
 
 export const passwordStyle = style({
   position: "relative",
-});
-
-export const passwordExpandStyle = styleVariants({
-  default: {
-    width: "fit-content",
-  },
-  expand: {
-    width: "100%",
-  },
 });
 
 export const passwordVisibleIconStyle = style({

--- a/packages/styles/bases/text-input.css.ts
+++ b/packages/styles/bases/text-input.css.ts
@@ -1,17 +1,8 @@
-import { style, styleVariants } from "@vanilla-extract/css";
+import { style } from "@vanilla-extract/css";
 import { THEME } from "@wizleap-inc/wiz-ui-constants";
 
 export const textInputStyle = style({
   position: "relative",
-});
-
-export const textInputExpandStyle = styleVariants({
-  default: {
-    width: "fit-content",
-  },
-  expand: {
-    width: "100%",
-  },
 });
 
 export const textInputIconStyle = style({

--- a/packages/wiz-ui-next/src/components/base/inputs/base/base.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/base/base.vue
@@ -47,6 +47,9 @@ const props = defineProps({
     type: Boolean,
     required: false,
   },
+  /**
+   * @deprecated このプロパティは将来のバージョンで削除される予定です。代わりに `width="100%"` を使用してください。
+   */
   expand: {
     type: Boolean,
     required: false,

--- a/packages/wiz-ui-next/src/components/base/inputs/date-range-picker/date-range-picker.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/date-range-picker/date-range-picker.vue
@@ -1,13 +1,13 @@
 <template>
-  <WizPopupContainer :expand="expand">
+  <WizPopupContainer :width="computedWidth">
     <button
       type="button"
       :class="[
         styles.variantStyles[variant],
         styles.bodyStyle[disabled ? 'disabled' : 'active'],
-        styles.widthStyle[expand ? 'expanded' : 'default'],
         inputBorderStyle[borderState],
       ]"
+      style="width: 100%"
       :aria-label="ARIA_LABELS.RANGE_DATE_PICKER_INPUT"
       :disabled="disabled"
       @click="setIsOpen(!isOpen)"
@@ -206,10 +206,18 @@ const props = defineProps({
     type: Object as PropType<DateRange>,
     required: true,
   },
+  /**
+   * @deprecated このプロパティは将来のバージョンで削除される予定です。代わりに `width="100%"` を使用してください。
+   */
   expand: {
     type: Boolean,
     required: false,
     default: false,
+  },
+  width: {
+    type: String,
+    required: false,
+    default: "20rem",
   },
   disabled: {
     type: Boolean,
@@ -265,6 +273,8 @@ const props = defineProps({
 });
 
 const emit = defineEmits<Emit>();
+
+const computedWidth = computed(() => (props.expand ? "100%" : props.width));
 
 const isSelectBoxOpen = ref(false);
 const selectBoxContainerRef = ref<HTMLElement>();

--- a/packages/wiz-ui-next/src/components/base/inputs/password/password.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/password/password.vue
@@ -5,7 +5,6 @@
       :placeholder="placeholder"
       :id="id"
       :disabled="disabled"
-      :expand="expand"
       width="100%"
       :error="isError"
       :type="!disabled && isPasswordVisible ? 'text' : 'password'"
@@ -85,7 +84,7 @@ const props = defineProps({
   width: {
     type: String,
     required: false,
-    default: "fit-content",
+    default: "10em",
   },
   autocomplete: {
     type: String as PropType<

--- a/packages/wiz-ui-next/src/components/base/inputs/password/password.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/password/password.vue
@@ -1,12 +1,12 @@
 <template>
-  <div :class="[passwordStyle, passwordExpandStyle[computedExpand]]">
+  <div :class="[passwordStyle]" :style="{ width: computedWidth }">
     <PrivateBaseInput
       v-model="passwordValue"
       :placeholder="placeholder"
       :id="id"
       :disabled="disabled"
       :expand="expand"
-      :width="width"
+      width="100%"
       :error="isError"
       :type="!disabled && isPasswordVisible ? 'text' : 'password'"
       :autocomplete="autocomplete"
@@ -37,7 +37,6 @@ import {
   ComponentName,
 } from "@wizleap-inc/wiz-ui-constants";
 import {
-  passwordExpandStyle,
   passwordStyle,
   passwordVisibleIconActiveStyle,
   passwordVisibleIconStyle,
@@ -76,6 +75,9 @@ const props = defineProps({
     type: Boolean,
     required: false,
   },
+  /**
+   * @deprecated このプロパティは将来のバージョンで削除される予定です。代わりに `width="100%"` を使用してください。
+   */
   expand: {
     type: Boolean,
     required: false,
@@ -83,6 +85,7 @@ const props = defineProps({
   width: {
     type: String,
     required: false,
+    default: "fit-content",
   },
   autocomplete: {
     type: String as PropType<
@@ -102,7 +105,7 @@ const passwordValue = computed({
   set: (value) => emit("update:modelValue", value),
 });
 
-const computedExpand = computed(() => (props.expand ? "expand" : "default"));
+const computedWidth = computed(() => (props.expand ? "100%" : props.width));
 
 // Form Control
 const form = inject(formControlKey);

--- a/packages/wiz-ui-next/src/components/base/inputs/search-input/search-input.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/search-input/search-input.vue
@@ -1,5 +1,5 @@
 <template>
-  <WizPopupContainer :expand="expand">
+  <WizPopupContainer :width="computedInputWidth">
     <div
       :class="[
         styles.searchStyle,
@@ -7,7 +7,7 @@
         disabled && styles.searchInputDisabledStyle,
         inputBorderStyle[state],
       ]"
-      :style="{ width: computedInputWidth }"
+      style="width: '100%'"
     >
       <div :class="styles.searchInputInnerBoxStyle">
         <WizHStack align="center" gap="xs">
@@ -116,6 +116,9 @@ type Props<T extends CheckboxOption> = {
   name: string;
   placeholder?: string;
   disabled?: boolean;
+  /**
+   * @deprecated このプロパティは将来のバージョンで削除される予定です。代わりに `inputWidth="100%"` を使用してください。
+   */
   expand?: boolean;
   inputWidth?: string;
   popupWidth?: string;

--- a/packages/wiz-ui-next/src/components/base/inputs/search-input/search-input.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/search-input/search-input.vue
@@ -7,7 +7,7 @@
         disabled && styles.searchInputDisabledStyle,
         inputBorderStyle[state],
       ]"
-      style="width: '100%'"
+      style="width: 100%"
     >
       <div :class="styles.searchInputInnerBoxStyle">
         <WizHStack align="center" gap="xs">

--- a/packages/wiz-ui-next/src/components/base/inputs/search-selector/search-selector.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/search-selector/search-selector.vue
@@ -1,5 +1,5 @@
 <template>
-  <WizPopupContainer :expand="expand">
+  <WizPopupContainer :width="computedWidth">
     <div
       :class="[
         selectBoxStyle,
@@ -7,7 +7,7 @@
         disabled && selectBoxDisabledStyle,
         selectBoxCursorStyle[selectBoxCursor],
       ]"
-      :style="{ width: computedWidth }"
+      style="width: 100%"
     >
       <div :class="selectBoxInnerBoxStyle" @click="toggleDropdown">
         <WizHStack align="center" height="100%" gap="xs" pr="xl" :wrap="true">
@@ -146,6 +146,9 @@ type Props<T> = {
   placeholder?: string;
   width?: string;
   disabled?: boolean;
+  /**
+   * @deprecated このプロパティは将来のバージョンで削除される予定です。代わりに `width="100%"` を使用してください。
+   */
   expand?: boolean;
   multiSelectable?: boolean;
   addable?: boolean;

--- a/packages/wiz-ui-next/src/components/base/inputs/selectbox/selectbox.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/selectbox/selectbox.vue
@@ -1,5 +1,5 @@
 <template>
-  <WizPopupContainer :expand="expand">
+  <WizPopupContainer :width="computedWidth">
     <div
       :class="[
         selectBoxStyle,
@@ -7,7 +7,7 @@
         disabled && selectBoxDisabledStyle,
         selectBoxCursorStyle[selectBoxCursor],
       ]"
-      :style="{ width: computedWidth }"
+      style="width: 100%"
     >
       <div :class="selectBoxInnerBoxStyles[variant]" @click="toggleSelectBox">
         <WizHStack align="center" justify="between" height="100%">
@@ -102,6 +102,9 @@ type Props<T> = {
   placeholder?: string;
   width?: string;
   disabled?: boolean;
+  /**
+   * @deprecated このプロパティは将来のバージョンで削除される予定です。代わりに `width="100%"` を使用してください。
+   */
   expand?: boolean;
   isOpen?: boolean;
   isDirectionFixed?: boolean;

--- a/packages/wiz-ui-next/src/components/base/inputs/text/text.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/text/text.vue
@@ -6,7 +6,6 @@
       :id="id"
       :placeholder="placeholder"
       :disabled="disabled"
-      :expand="expand"
       width="100%"
       :error="isError"
       type="text"
@@ -56,7 +55,7 @@ const props = defineProps({
   width: {
     type: String,
     required: false,
-    default: "fit-content",
+    default: "10em",
   },
   /**
    * @deprecated このプロパティは将来のバージョンで削除される予定です。代わりに `width="100%"` を使用してください。

--- a/packages/wiz-ui-next/src/components/base/inputs/text/text.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/text/text.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="[textInputStyle, textInputExpandStyle[computedExpand]]">
+  <div :class="[textInputStyle]" :style="{ width: computedWidth }">
     <component :class="textInputIconStyle" :is="icon" />
     <PrivateBaseInput
       v-model="textValue"
@@ -7,7 +7,7 @@
       :placeholder="placeholder"
       :disabled="disabled"
       :expand="expand"
-      :width="width"
+      width="100%"
       :error="isError"
       type="text"
       :space-type="icon ? 'left' : 'none'"
@@ -22,7 +22,6 @@
 import { AutoCompleteKeys, ComponentName } from "@wizleap-inc/wiz-ui-constants";
 import {
   textInputStyle,
-  textInputExpandStyle,
   textInputIconStyle,
 } from "@wizleap-inc/wiz-ui-styles/bases/text-input.css";
 import { computed, inject, PropType } from "vue";
@@ -57,7 +56,11 @@ const props = defineProps({
   width: {
     type: String,
     required: false,
+    default: "fit-content",
   },
+  /**
+   * @deprecated このプロパティは将来のバージョンで削除される予定です。代わりに `width="100%"` を使用してください。
+   */
   expand: {
     type: Boolean,
     required: false,
@@ -89,7 +92,9 @@ const textValue = computed({
 const form = inject(formControlKey);
 const isError = computed(() => (form ? form.isError.value : false));
 
-const computedExpand = computed(() => (props.expand ? "expand" : "default"));
+const computedWidth = computed(() =>
+  props.expand ? "100%" : props.width || "fit-content"
+);
 
 const onFocusIn = (e: FocusEvent) => emit("focusin", e);
 const onFocusOut = (e: FocusEvent) => emit("focusout", e);

--- a/packages/wiz-ui-react/src/components/base/inputs/base/components/base-input.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/base/components/base-input.tsx
@@ -10,6 +10,9 @@ type Props = BaseProps & {
   value?: string;
   placeholder?: string;
   disabled?: boolean;
+  /**
+   * @deprecated このプロパティは将来のバージョンで削除される予定です。代わりに `width="100%"` を使用してください。
+   */
   expand?: boolean;
   type?: "text" | "password";
   width?: string;

--- a/packages/wiz-ui-react/src/components/base/inputs/date-range-picker/components/date-range-picker.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/date-range-picker/components/date-range-picker.tsx
@@ -37,7 +37,11 @@ import { DateRange, DateRangePickerSelectBoxOption } from "../types";
 
 type Props = BaseProps & {
   dateRange: DateRange;
+  /**
+   * @deprecated このプロパティは将来のバージョンで削除される予定です。代わりに `width="100%"` を使用してください。
+   */
   expand?: boolean;
+  width?: string;
   disabled?: boolean;
   selectBoxOptions?: DateRangePickerSelectBoxOption[];
   selectBoxValue?: string;
@@ -60,6 +64,8 @@ const DateRangePicker: FC<Props> = ({
   style,
   dateRange,
   expand = false,
+  // width = '20rem',
+  width,
   disabled = false,
   selectBoxOptions,
   selectBoxValue,
@@ -89,6 +95,9 @@ const DateRangePicker: FC<Props> = ({
       return new Date();
     })()
   );
+
+  const computedWidth = width || (expand ? "100%" : "20rem");
+
   const leftCalendarDate = useMemo(
     () =>
       new Date(
@@ -231,12 +240,11 @@ const DateRangePicker: FC<Props> = ({
         onClick={() => setIsOpen(!isOpen)}
         onKeyDown={handleKeyDown}
         disabled={disabled}
-        style={style}
+        style={{ ...style, width: computedWidth }}
         className={clsx(
           className,
           styles.bodyStyle[disabled ? "disabled" : "active"],
           styles.variantStyles[variant],
-          styles.widthStyle[expand ? "expanded" : "default"],
           inputBorderStyle[borderStyle]
         )}
       >

--- a/packages/wiz-ui-react/src/components/base/inputs/password/components/password-input.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/password/components/password-input.tsx
@@ -39,7 +39,7 @@ const PasswordInput = forwardRef<HTMLInputElement, Props>(
       placeholder,
       disabled,
       expand,
-      width = "fit-content",
+      width = "10em",
       autocomplete = "off",
       error,
       onChange,

--- a/packages/wiz-ui-react/src/components/base/inputs/password/components/password-input.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/password/components/password-input.tsx
@@ -19,6 +19,9 @@ type Props = BaseProps & {
   value: string;
   placeholder?: string;
   disabled?: boolean;
+  /**
+   * @deprecated このプロパティは将来のバージョンで削除される予定です。代わりに `width="100%"` を使用してください。
+   */
   expand?: boolean;
   width?: string;
   autocomplete?: Extract<AutoCompleteKeys, "currentPassword" | "newPassword">;
@@ -36,7 +39,7 @@ const PasswordInput = forwardRef<HTMLInputElement, Props>(
       placeholder,
       disabled,
       expand,
-      width,
+      width = "fit-content",
       autocomplete = "off",
       error,
       onChange,
@@ -49,14 +52,12 @@ const PasswordInput = forwardRef<HTMLInputElement, Props>(
 
     const isError = error || formControl.error;
 
+    const computedWidth = expand ? "100%" : width;
+
     return (
       <div
-        className={clsx(
-          className,
-          styles.passwordStyle,
-          styles.passwordExpandStyle[expand ? "expand" : "default"]
-        )}
-        style={style}
+        className={clsx(className, styles.passwordStyle)}
+        style={{ ...style, width: computedWidth }}
       >
         <PrivateBaseInput
           ref={ref}
@@ -65,7 +66,7 @@ const PasswordInput = forwardRef<HTMLInputElement, Props>(
           id={id}
           disabled={disabled}
           expand={expand}
-          width={width}
+          width="100%"
           error={isError}
           type={!disabled && isPasswordVisible ? "text" : "password"}
           autoComplete={autocomplete}

--- a/packages/wiz-ui-react/src/components/base/inputs/search-input/components/search-input.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-input/components/search-input.tsx
@@ -23,6 +23,9 @@ type Props<T extends CheckboxOption> = BaseProps & {
   name?: string;
   placeholder?: string;
   disabled?: boolean;
+  /**
+   * @deprecated このプロパティは将来のバージョンで削除される予定です。代わりに `inputWidth="100%"` を使用してください。
+   */
   expand?: boolean;
   singleSelect?: boolean;
   inputWidth?: string;

--- a/packages/wiz-ui-react/src/components/base/inputs/search-selector/components/search-selector.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/search-selector/components/search-selector.tsx
@@ -36,6 +36,9 @@ type Props<T> = BaseProps & {
   placeholder?: string;
   width?: string;
   disabled?: boolean;
+  /**
+   * @deprecated このプロパティは将来のバージョンで削除される予定です。代わりに `width="100%"` を使用してください。
+   */
   expand?: boolean;
   multiSelectable?: boolean;
   addable?: boolean;

--- a/packages/wiz-ui-react/src/components/base/inputs/selectbox/components/selectbox.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/selectbox/components/selectbox.tsx
@@ -34,6 +34,9 @@ type Props<T> = BaseProps & {
   placeholder?: string;
   width?: string;
   disabled?: boolean;
+  /**
+   * @deprecated このプロパティは将来のバージョンで削除される予定です。代わりに `width="100%"` を使用してください。
+   */
   expand?: boolean;
   error?: boolean;
   isDirectionFixed?: boolean;

--- a/packages/wiz-ui-react/src/components/base/inputs/text/components/text-input.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/text/components/text-input.tsx
@@ -44,14 +44,12 @@ const TextInput = forwardRef(
       [onChange, onChangeValue]
     );
 
+    const computedWidth = props.expand ? "100%" : props.width || "fit-content";
+
     return (
       <div
-        className={clsx(
-          className,
-          styles.textInputStyle,
-          styles.textInputExpandStyle[props.expand ? "expand" : "default"]
-        )}
-        style={style}
+        className={clsx(className, styles.textInputStyle)}
+        style={{ ...style, width: computedWidth }}
       >
         {Icon && (
           <div className={styles.textInputIconStyle}>
@@ -61,6 +59,7 @@ const TextInput = forwardRef(
         <PrivateBaseInput
           {...props}
           ref={ref}
+          width="100%"
           error={error ?? formControl.error}
           type="text"
           onChange={handleChange}

--- a/packages/wiz-ui-react/src/components/base/inputs/text/components/text-input.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/text/components/text-input.tsx
@@ -44,7 +44,7 @@ const TextInput = forwardRef(
       [onChange, onChangeValue]
     );
 
-    const computedWidth = props.expand ? "100%" : props.width || "fit-content";
+    const computedWidth = props.expand ? "100%" : props.width || "10em";
 
     return (
       <div


### PR DESCRIPTION
resolve: #1441

## 対応すること
- inputs内でwidth propertyを使って自由に横幅を決めることができる
- 既にwidthで対応可能なComponentに関しても、expandは非推奨に
- widthを追加したComponentはこれまで通りexpandの設定を優先し動作が変わらないこと

### 対応したコンポーネント
- [x] DateRangePicker
- [x] Password
- [x] Text
### 対応しないコンポーネント
- [x] checkbox new
- [x] checkbox
- [x] ToggleSwitch
- [x] Upload