### PR TITLE
マージしない: VRTでFontの差分が出る現象の調査

### DIFF
--- a/.github/workflows/visual-regression-test.yml
+++ b/.github/workflows/visual-regression-test.yml
@@ -30,6 +30,27 @@ jobs:
       - name: Install fonts
         run: sudo apt-get install fonts-ipafont-gothic fonts-ipafont-mincho
 
+      - name: Log font information
+        run: |
+          echo "=== System Font Information ==="
+          echo "--- All Installed Fonts ---"
+          fc-list | sort
+
+          echo "--- Japanese Fonts ---"
+          fc-list :lang=ja
+
+          echo "--- IPA Fonts Details ---"
+          fc-list | grep -i ipa
+
+          echo "--- Font Cache Information ---"
+          fc-cache -v
+
+          echo "--- Font Configuration ---"
+          ls -la /etc/fonts/
+
+          echo "=== Font Log Summary ==="
+          echo "Japanese Fonts Count: $(fc-list :lang=ja | wc -l)"
+
       - name: workaround for detached HEAD
         run: |
           git checkout ${GITHUB_REF#refs/heads/} || git checkout -b ${GITHUB_REF#refs/heads/} && git pull


### PR DESCRIPTION
VRTの際にFontでDiffが出る問題解決のための調査ログを表示するPR

再現できないので
いつか問題が発生した日にCIをre-runしてログを取ってみる。
Mainにマージするほど望みがありそうにないので一旦PRに留める
