### PR TITLE
feat(textarea): ComponentPropsWithoutRef で data-* 属性を透過できるよう対応

### DIFF
--- a/packages/wiz-ui-react/src/components/base/text-area/components/text-area.tsx
+++ b/packages/wiz-ui-react/src/components/base/text-area/components/text-area.tsx
@@ -2,7 +2,7 @@ import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
 import * as styles from "@wizleap-inc/wiz-ui-styles/bases/text-area.css";
 import { inputBorderStyle } from "@wizleap-inc/wiz-ui-styles/commons";
 import clsx from "clsx";
-import { forwardRef, useContext } from "react";
+import { ComponentPropsWithoutRef, forwardRef, useContext } from "react";
 
 import { FormControlContext } from "@/components/custom/form/components/form-control-context";
 import { BaseProps } from "@/types";
@@ -12,12 +12,8 @@ function getInputBorderStyleKey(isError?: boolean) {
 }
 
 type Props = BaseProps & {
-  id?: string;
   value: string;
-  placeholder?: string;
-  disabled?: boolean;
   expand?: boolean;
-  rows?: number;
   error?: boolean;
   resize?: "none" | "both" | "horizontal" | "vertical";
   maxWidth?: string;
@@ -25,19 +21,17 @@ type Props = BaseProps & {
   maxHeight?: string;
   minHeight?: string;
   onChange?: (value: string) => void;
-};
+} & Omit<
+    ComponentPropsWithoutRef<"textarea">,
+    "onChange" | "style" | "className"
+  >;
 
 const TextArea = forwardRef<HTMLTextAreaElement, Props>(
   (
     {
       className,
       style,
-      id,
-      value,
-      placeholder,
-      disabled,
       expand,
-      rows = 3,
       error,
       resize = "none",
       maxWidth,
@@ -45,6 +39,8 @@ const TextArea = forwardRef<HTMLTextAreaElement, Props>(
       maxHeight,
       minHeight,
       onChange,
+      rows = 3,
+      ...props
     },
     ref
   ) => {
@@ -55,10 +51,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, Props>(
     return (
       <textarea
         ref={ref}
-        id={id}
-        value={value}
-        placeholder={placeholder}
-        disabled={disabled}
+        {...props}
         rows={rows}
         style={{
           ...style,


### PR DESCRIPTION
resolve: #1218

このPRはdata-*属性の対応方針のため、実装に問題がなければCloseして、別コンポーネントも対応を進めます。
対応方針として、既に割と大半のコンポーネントが受け取れるようになっているようだったので、未実施かつシンプルな（実装に悩まないもの）ものを一旦まとめてPRを出す予定です。

### 概要
`data-*` 属性を渡せるようにするため、`ComponentPropsWithoutRef<'input'>` を採用しました。  
これにより `...rest` を安全に `<input>` にスプレッドでき、E2E テストなどで `data-testid` を用いた要素特定が可能になります。

### 対応内容
- **既存のコンポーネントで採用されていた`ComponentProps` ではなく`ComponentPropsWithoutRef` で対応**
  - `style` / `className` / `onChange` など重複プロパティを `Omit` で除外し、`BaseProps` に一本化
  - `forwardRef` の第 2 引数で `ref` を受け取り、`props` には含めない形に統一
- **型のねじれを解消**
  - `props.ref` が常に `undefined` になる潜在バグを排除
  - 今後 `forwardRef` を外した際も即座に型エラーが出るため安全

### 他コンポーネントとの整合性
- 既存コードには `ComponentProps` を使用している箇所が残っていますが、`forwardRef` と併用すると型と挙動がズレるため、今後 **WithoutRef への置換** を順次進めます。

### React 19 との兼ね合い（参考）
- React 19 では `ref` が通常の prop として渡り、`forwardRef` は非推奨予定。
- 公式 codemod（`react/19/remove-forward-ref`）で一括変換可能なため、当面は現行実装を維持し、アップグレード時に一括置換で対応予定です。

