### PR TITLE
Feat: E2Eテストのためdata-*をComponentに付与できるようにする(一部）

### DIFF
--- a/.changeset/perfect-ghosts-scream.md
+++ b/.changeset/perfect-ghosts-scream.md
@@ -1,0 +1,5 @@
+---
+"@wizleap-inc/wiz-ui-react": patch
+---
+
+E2E テストのため data-testid を Component に付与できるようにする

--- a/packages/wiz-ui-react/src/components/base/accordion/components/accordion.tsx
+++ b/packages/wiz-ui-react/src/components/base/accordion/components/accordion.tsx
@@ -11,7 +11,7 @@ import { WizHStack, WizIExpandMore, WizIcon } from "@/components";
 
 import { useToggleAnimation } from "./use-toggle-animation";
 
-type Props = ComponentPropsWithoutRef<"details"> & {
+type Props = Omit<ComponentPropsWithoutRef<"details">, "onToggle"> & {
   isOpen: boolean;
   openMessage?: string;
   closeMessage?: string;

--- a/packages/wiz-ui-react/src/components/base/accordion/components/accordion.tsx
+++ b/packages/wiz-ui-react/src/components/base/accordion/components/accordion.tsx
@@ -5,14 +5,13 @@ import {
   colorStyle,
 } from "@wizleap-inc/wiz-ui-styles/commons";
 import clsx from "clsx";
-import { FC, ReactNode } from "react";
+import { FC, ReactNode, ComponentPropsWithoutRef } from "react";
 
 import { WizHStack, WizIExpandMore, WizIcon } from "@/components";
-import { BaseProps } from "@/types";
 
 import { useToggleAnimation } from "./use-toggle-animation";
 
-type Props = BaseProps & {
+type Props = ComponentPropsWithoutRef<"details"> & {
   isOpen: boolean;
   openMessage?: string;
   closeMessage?: string;
@@ -34,12 +33,14 @@ const Accordion: FC<Props> = ({
   fontColor = "gray.600",
   children,
   onToggle,
+  ...props
 }) => {
   const { isActuallyOpen, isAnimating, contentRef } =
     useToggleAnimation(isOpen);
 
   return (
     <details
+      {...props}
       open={isActuallyOpen}
       style={{ ...style, width }}
       className={clsx(

--- a/packages/wiz-ui-react/src/components/base/dropdown/components/dropdown-item.tsx
+++ b/packages/wiz-ui-react/src/components/base/dropdown/components/dropdown-item.tsx
@@ -1,25 +1,22 @@
 import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
 import * as styles from "@wizleap-inc/wiz-ui-styles/bases/dropdown.css";
 import clsx from "clsx";
-import { FC, MouseEventHandler, ReactNode, useState } from "react";
+import { ComponentPropsWithoutRef, FC, ReactNode, useState } from "react";
 
 import { WizHStack, WizIcon } from "@/components";
 import { TIcon } from "@/components/icons";
-import { BaseProps } from "@/types";
-type Props = BaseProps & {
+
+type Props = ComponentPropsWithoutRef<"button"> & {
   icon?: TIcon;
-  disabled?: boolean;
-  onClick?: MouseEventHandler<HTMLButtonElement>;
   children: ReactNode;
 };
 
 const DropdownItem: FC<Props> = ({
   className,
-  style,
   icon,
-  disabled = false,
   onClick,
   children,
+  ...props
 }) => {
   const [isHover, setIsHover] = useState(false);
   const [isPressed, setIsPressed] = useState(false);
@@ -36,10 +33,9 @@ const DropdownItem: FC<Props> = ({
 
   return (
     <button
+      {...props}
       type="button"
       className={clsx(className, styles.dropdownItemStyle)}
-      style={style}
-      disabled={disabled}
       onClick={onClick}
       onMouseOver={() => setIsHover(true)}
       onMouseOut={() => setIsHover(false)}

--- a/packages/wiz-ui-react/src/components/base/inputs/toggle-switch/components/toggle-switch.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/toggle-switch/components/toggle-switch.tsx
@@ -1,10 +1,9 @@
 import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
 import * as styles from "@wizleap-inc/wiz-ui-styles/bases/toggle-switch-input.css";
 import clsx from "clsx";
-import { FC } from "react";
+import { FC, ComponentPropsWithoutRef } from "react";
 
-import { BaseProps } from "@/types";
-type Props = BaseProps & {
+type Props = ComponentPropsWithoutRef<"label"> & {
   value: boolean;
   ariaLabel: string;
   disabled?: boolean;
@@ -13,7 +12,6 @@ type Props = BaseProps & {
 
 const ToggleSwitch: FC<Props> = ({
   className,
-  style,
   value,
   ariaLabel,
   disabled,
@@ -22,7 +20,7 @@ const ToggleSwitch: FC<Props> = ({
   const switchState = value ? "checked" : "default";
 
   return (
-    <label className={clsx(className, styles.toggleSwitchStyle)} style={style}>
+    <label {...props} className={clsx(className, styles.toggleSwitchStyle)}>
       <input
         className={styles.toggleSwitchInputStyle}
         type="checkbox"

--- a/packages/wiz-ui-react/src/components/base/navigation/components/navigation-item.tsx
+++ b/packages/wiz-ui-react/src/components/base/navigation/components/navigation-item.tsx
@@ -13,6 +13,7 @@ import {
 import clsx from "clsx";
 import {
   ComponentProps,
+  ComponentPropsWithoutRef,
   ElementType,
   useCallback,
   useMemo,
@@ -28,11 +29,10 @@ import {
   WizPopupButtonGroup,
   WizTooltip,
 } from "@/components";
-import { BaseProps } from "@/types";
 
 import { ButtonGroupItem, ButtonItem } from "../../popup-button-group/types";
 
-type Props<T extends ElementType> = BaseProps & {
+type Props<T extends ElementType> = ComponentPropsWithoutRef<"div"> & {
   icon: TIcon;
   label: string;
   active: boolean;
@@ -77,7 +77,6 @@ type Props<T extends ElementType> = BaseProps & {
  * ```
  */
 const NavigationItem = <T extends ElementType>({
-  className,
   style,
   icon: Icon,
   label,
@@ -148,9 +147,9 @@ const NavigationItem = <T extends ElementType>({
 
   const body = (
     <div
+      {...props}
       ref={popupAnchor}
       onClick={handleClick}
-      className={className}
       style={{ ...style, display: tooltipText ? "block" : "inline-block" }}
     >
       <LinkComponent

--- a/packages/wiz-ui-react/src/components/base/navigation/components/navigation-item.tsx
+++ b/packages/wiz-ui-react/src/components/base/navigation/components/navigation-item.tsx
@@ -85,22 +85,25 @@ const NavigationItem = <T extends ElementType>({
   tooltipText,
   buttons,
   isPopupOpen = false,
+  href,
+  as,
+  asProps,
   onTogglePopup,
   ...props
 }: Props<T>) => {
-  const isAnchor = "href" in props && props.as === undefined;
-  const LinkComponent = props.as || "a";
-  const isExternalLink = !!props?.href?.startsWith("http");
+  const isAnchor = href && as === undefined;
+  const LinkComponent = as || "a";
+  const isExternalLink = !!href?.startsWith("http");
   const linkProps = isAnchor
     ? {
-        href: disabled ? undefined : props.href ?? "",
+        href: disabled ? undefined : href ?? "",
         target: !disabled && isExternalLink ? "_blank" : undefined,
       }
     : {
-        ...props.asProps,
+        ...asProps,
         style: {
           cursor: disabled ? "not-allowed" : "pointer",
-          ...props.asProps?.style,
+          ...asProps?.style,
         },
       };
   const popupAnchor = useRef<HTMLDivElement>(null);

--- a/packages/wiz-ui-react/src/components/base/pagination/components/pagination.tsx
+++ b/packages/wiz-ui-react/src/components/base/pagination/components/pagination.tsx
@@ -1,14 +1,14 @@
 import { ARIA_LABELS, ComponentName } from "@wizleap-inc/wiz-ui-constants";
 import * as styles from "@wizleap-inc/wiz-ui-styles/bases/pagination.css";
 import clsx from "clsx";
+import { ComponentPropsWithoutRef } from "react";
 
 import { WizIcon } from "@/components";
 import { WizIChevronLeft, WizIChevronRight } from "@/components/icons";
-import { BaseProps } from "@/types";
 
 import { DivButton } from "./private-div-button";
 
-type Props = BaseProps & {
+type Props = ComponentPropsWithoutRef<"nav"> & {
   currentPage: number;
   length: number;
   onChangePage?: (page: number) => void;
@@ -21,11 +21,11 @@ type Props = BaseProps & {
 
 const Pagination = ({
   className,
-  style,
   currentPage,
   length,
   onChangePage,
   sideLength = 2,
+  ...props
 }: Props) => {
   const sideItemLength = Math.max(0, sideLength);
   const maxItemLength = 2 * sideItemLength + 1;
@@ -56,13 +56,13 @@ const Pagination = ({
   };
   return (
     <nav
+      {...props}
       className={clsx(
         className,
         styles.paginationStyle,
         currentPage <= 1 && styles.paginationGapStyle["left"],
         currentPage >= length && styles.paginationGapStyle["right"]
       )}
-      style={style}
       aria-label={ARIA_LABELS.PAGINATION}
     >
       {currentPage > 1 && (

--- a/packages/wiz-ui-react/src/components/base/panel-switch/components/panel-switch.tsx
+++ b/packages/wiz-ui-react/src/components/base/panel-switch/components/panel-switch.tsx
@@ -5,7 +5,7 @@ import { FC, useId, ComponentPropsWithoutRef } from "react";
 
 import { PanelItems } from "./type";
 
-type Props = ComponentPropsWithoutRef<"div"> & {
+type Props = Omit<ComponentPropsWithoutRef<"div">, "onChange"> & {
   value: number | null;
   items: PanelItems[];
   width?: string;

--- a/packages/wiz-ui-react/src/components/base/panel-switch/components/panel-switch.tsx
+++ b/packages/wiz-ui-react/src/components/base/panel-switch/components/panel-switch.tsx
@@ -1,13 +1,11 @@
 import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
 import * as styles from "@wizleap-inc/wiz-ui-styles/bases/panel-switch-input.css";
 import clsx from "clsx";
-import { FC, useId } from "react";
-
-import { BaseProps } from "@/types";
+import { FC, useId, ComponentPropsWithoutRef } from "react";
 
 import { PanelItems } from "./type";
 
-type Props = BaseProps & {
+type Props = ComponentPropsWithoutRef<"div"> & {
   value: number | null;
   items: PanelItems[];
   width?: string;
@@ -21,11 +19,13 @@ const PanelSwitch: FC<Props> = ({
   items,
   width,
   onChange,
+  ...props
 }) => {
   const idPrefix = useId();
 
   return (
     <div
+      {...props}
       className={clsx(className, styles.panelSwitchStyle)}
       style={{ ...style, ...(width ? { width } : {}) }}
     >

--- a/packages/wiz-ui-react/src/components/base/show-more-less/components/show-more-less.tsx
+++ b/packages/wiz-ui-react/src/components/base/show-more-less/components/show-more-less.tsx
@@ -15,11 +15,11 @@ import {
   useEffect,
   useRef,
   useState,
+  ComponentPropsWithoutRef,
 } from "react";
 
 import { WizHStack, WizIExpandMore, WizIcon, WizVStack } from "@/components";
-import { BaseProps } from "@/types";
-type Props = BaseProps & {
+type Props = ComponentPropsWithoutRef<"div"> & {
   isOpen: boolean;
   openMessage?: string;
   closeMessage?: string;
@@ -39,6 +39,7 @@ const ShowMoreLess: FC<Props> = ({
   variant = "pc",
   onToggle,
   children,
+  ...props
 }) => {
   const contentRef = useRef<HTMLDivElement>(null);
   const [height, setHeight] = useState<string>("0px");
@@ -56,6 +57,7 @@ const ShowMoreLess: FC<Props> = ({
 
   return (
     <div
+      {...props}
       className={clsx(className, showMoreLessDetailsStyle)}
       style={{ ...style, width: width }}
     >

--- a/packages/wiz-ui-react/src/components/base/tab/components/tab.tsx
+++ b/packages/wiz-ui-react/src/components/base/tab/components/tab.tsx
@@ -1,13 +1,12 @@
 import { ComponentName, SpacingKeys } from "@wizleap-inc/wiz-ui-constants";
-import { FC } from "react";
+import { FC, ComponentPropsWithoutRef } from "react";
 
 import { WizHStack } from "@/components";
-import { BaseProps } from "@/types";
 
 import { WizTabPane } from "./tab-pane";
 import { TabItem } from "./types";
 
-type Props = BaseProps & {
+type Props = ComponentPropsWithoutRef<"div"> & {
   activeTabName: string;
   items: TabItem[];
   gap?: SpacingKeys;
@@ -25,9 +24,11 @@ const Tab: FC<Props> = ({
   width,
   center = false,
   onClickTab,
+  ...props
 }: Props) => {
   return (
     <WizHStack
+      {...props}
       className={className}
       style={style}
       gap={gap}

--- a/packages/wiz-ui-react/src/components/base/tab/components/tab.tsx
+++ b/packages/wiz-ui-react/src/components/base/tab/components/tab.tsx
@@ -16,8 +16,6 @@ type Props = ComponentPropsWithoutRef<"div"> & {
 };
 
 const Tab: FC<Props> = ({
-  className,
-  style,
   activeTabName,
   items,
   gap,
@@ -29,8 +27,6 @@ const Tab: FC<Props> = ({
   return (
     <WizHStack
       {...props}
-      className={className}
-      style={style}
       gap={gap}
       nowrap
       justify={center ? "center" : undefined}

--- a/packages/wiz-ui-react/src/components/base/text-area/components/text-area.tsx
+++ b/packages/wiz-ui-react/src/components/base/text-area/components/text-area.tsx
@@ -2,22 +2,22 @@ import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
 import * as styles from "@wizleap-inc/wiz-ui-styles/bases/text-area.css";
 import { inputBorderStyle } from "@wizleap-inc/wiz-ui-styles/commons";
 import clsx from "clsx";
-import { forwardRef, useContext } from "react";
+import { ComponentPropsWithoutRef, forwardRef, useContext } from "react";
 
 import { FormControlContext } from "@/components/custom/form/components/form-control-context";
-import { BaseProps } from "@/types";
 function getInputBorderStyleKey(isError?: boolean) {
   if (isError) return "error";
   return "default";
 }
 
-type Props = BaseProps & {
-  id?: string;
+type TextAreaHTMLProps = Omit<
+  ComponentPropsWithoutRef<"textarea">,
+  "value" | "onChange"
+>;
+
+type Props = TextAreaHTMLProps & {
   value: string;
-  placeholder?: string;
-  disabled?: boolean;
   expand?: boolean;
-  rows?: number;
   error?: boolean;
   resize?: "none" | "both" | "horizontal" | "vertical";
   maxWidth?: string;
@@ -32,10 +32,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, Props>(
     {
       className,
       style,
-      id,
       value,
-      placeholder,
-      disabled,
       expand,
       rows = 3,
       error,
@@ -45,6 +42,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, Props>(
       maxHeight,
       minHeight,
       onChange,
+      ...props
     },
     ref
   ) => {
@@ -54,11 +52,9 @@ const TextArea = forwardRef<HTMLTextAreaElement, Props>(
 
     return (
       <textarea
+        {...props}
         ref={ref}
-        id={id}
         value={value}
-        placeholder={placeholder}
-        disabled={disabled}
         rows={rows}
         style={{
           ...style,

--- a/packages/wiz-ui-react/src/components/custom/chat/components/chat-card.tsx
+++ b/packages/wiz-ui-react/src/components/custom/chat/components/chat-card.tsx
@@ -3,6 +3,7 @@ import * as styles from "@wizleap-inc/wiz-ui-styles/customs/chat-card.css";
 import { formatDateToMonthDayWeek } from "@wizleap-inc/wiz-ui-utils";
 import {
   ComponentProps,
+  ComponentPropsWithoutRef,
   Fragment,
   useCallback,
   useEffect,
@@ -25,7 +26,6 @@ import {
   WizText,
   WizVStack,
 } from "@/components";
-import { BaseProps } from "@/types";
 
 import { DisplayMessage, Message } from "./types";
 
@@ -33,7 +33,7 @@ import { WizChatForm, WizChatItem } from ".";
 
 const TOGGLE_ANIMATION_DURATION = 300;
 
-type Props<T> = BaseProps & {
+type Props<T> = ComponentPropsWithoutRef<"div"> & {
   textValue: string;
   username: string;
   isOpen: boolean;
@@ -52,8 +52,6 @@ type Props<T> = BaseProps & {
 };
 
 const ChatCard = <T,>({
-  className,
-  style,
   isOpen,
   textValue,
   username,
@@ -69,6 +67,7 @@ const ChatCard = <T,>({
   onChangeTextValue,
   onSubmit,
   onToggle,
+  ...props
 }: Props<T>) => {
   const wrapperBoxRef = useRef<HTMLDivElement>(null);
   const dividerRef = useRef<HTMLDivElement>(null);
@@ -140,8 +139,7 @@ const ChatCard = <T,>({
 
   return (
     <WizBox
-      className={className}
-      style={style}
+      {...props}
       ref={wrapperBoxRef}
       position="fixed"
       right="1.5rem"

--- a/packages/wiz-ui-react/src/components/custom/chat/components/chat-card.tsx
+++ b/packages/wiz-ui-react/src/components/custom/chat/components/chat-card.tsx
@@ -33,7 +33,7 @@ import { WizChatForm, WizChatItem } from ".";
 
 const TOGGLE_ANIMATION_DURATION = 300;
 
-type Props<T> = ComponentPropsWithoutRef<"div"> & {
+type Props<T> = Omit<ComponentPropsWithoutRef<"div">, "onSubmit"> & {
   textValue: string;
   username: string;
   isOpen: boolean;


### PR DESCRIPTION
resolve: #1218

# タスク
E2Eテストのためdata-testidをComponentに付与できるようにするために、Wrapperにその属性の取りうる値をpropsで渡せるようにしました。
どこにつけるかは、Issuesでまとめており何も書いてないのはWrapperにつけるということで合意が取れております。

- シンプルに親要素につけるだけのものを対応しました（anchorは別対応します)

## 今回対象のコンポーネント
- [x] text-area
- [x] accordion
- [x] dropdown-item
- [x] input-toggle-switch
- [x] navigation-item
- [x] pagination
- [x] panel-switch
- [x] show-more-less
- [x] tab
- [x] chat

## Test
https://github.com/Wizleap-Inc/wiz-ui/pull/1488