### PR TITLE
feat(date-picker): ポップアップにユニークなIDを付与

### DIFF
--- a/.changeset/gentle-houses-kick.md
+++ b/.changeset/gentle-houses-kick.md
@@ -1,0 +1,6 @@
+---
+"@wizleap-inc/wiz-ui-react": minor
+"@wizleap-inc/wiz-ui-next": minor
+---
+
+DatepickerのPopupにユニークなIDを付与する

--- a/packages/wiz-ui-next/src/components/base/inputs/date-picker/date-picker.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/date-picker/date-picker.vue
@@ -39,7 +39,10 @@
       :is-direction-fixed="isDirectionFixed"
       @on-close="onClose"
     >
-      <div :class="datePickerSelectorStyle">
+      <div
+        :id="attrs.id ? `date-picker-popup-${attrs.id}` : undefined"
+        :class="datePickerSelectorStyle"
+      >
         <WizHStack align="center" my="xs2" justify="between">
           <WizHStack align="center" pl="xs" gap="xs">
             <WizHStack align="center" gap="xs2">
@@ -153,7 +156,7 @@ import {
   fontSizeStyle,
   inputBorderStyle,
 } from "@wizleap-inc/wiz-ui-styles/commons";
-import { PropType, computed, inject, ref } from "vue";
+import { PropType, computed, inject, ref, useAttrs } from "vue";
 
 import {
   WizCalendar,
@@ -253,6 +256,7 @@ const props = defineProps({
 
 const emit = defineEmits<Emit>();
 
+const attrs = useAttrs();
 const defaultCurrentMonth = props.modelValue || new Date();
 const currentMonth = ref(defaultCurrentMonth);
 

--- a/packages/wiz-ui-next/src/components/base/inputs/date-range-picker/date-range-picker.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/date-range-picker/date-range-picker.vue
@@ -57,7 +57,10 @@
       :is-direction-fixed="isDirectionFixed"
       @on-close="onClose"
     >
-      <WizCard p="no">
+      <WizCard
+        :id="attrs.id ? `date-range-picker-popup-${attrs.id}` : undefined"
+        p="no"
+      >
         <div :class="styles.popupStyle">
           <div v-if="selectBoxOptions" :class="styles.popupHeaderStyle">
             <div
@@ -170,7 +173,7 @@
 import { ARIA_LABELS } from "@wizleap-inc/wiz-ui-constants";
 import * as styles from "@wizleap-inc/wiz-ui-styles/bases/date-range-picker.css";
 import { inputBorderStyle } from "@wizleap-inc/wiz-ui-styles/commons";
-import { computed, inject, PropType, ref } from "vue";
+import { computed, inject, PropType, ref, useAttrs } from "vue";
 
 import {
   WizCalendar,
@@ -274,6 +277,7 @@ const props = defineProps({
 
 const emit = defineEmits<Emit>();
 
+const attrs = useAttrs();
 const computedWidth = computed(() => (props.expand ? "100%" : props.width));
 
 const isSelectBoxOpen = ref(false);

--- a/packages/wiz-ui-react/src/components/base/inputs/date-picker/components/date-picker.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/date-picker/components/date-picker.tsx
@@ -145,6 +145,8 @@ const DatePicker: FC<Props> = ({
     setIsOpen(false);
   };
 
+  const { id } = props;
+
   return (
     <>
       <button
@@ -192,7 +194,10 @@ const DatePicker: FC<Props> = ({
         isDirectionFixed={isDirectionFixed}
         anchorElement={wrapperButtonRef}
       >
-        <div className={styles.datePickerSelectorStyle}>
+        <div
+          id={id ? `date-picker-popup-${id}` : undefined}
+          className={styles.datePickerSelectorStyle}
+        >
           <WizHStack align="center" my="xs2" justify="between">
             <WizHStack align="center" pl="xs" gap="xs">
               <WizHStack align="center" gap="xs2">

--- a/packages/wiz-ui-react/src/components/base/inputs/date-range-picker/components/date-range-picker.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/date-range-picker/components/date-range-picker.tsx
@@ -231,6 +231,8 @@ const DateRangePicker: FC<Props> = ({
     onChangeDateRange?.(tempDateRange);
     setIsOpen(false);
   };
+
+  const { id } = props;
   return (
     <>
       <button
@@ -303,7 +305,7 @@ const DateRangePicker: FC<Props> = ({
         isDirectionFixed={isDirectionFixed}
         anchorElement={anchor}
       >
-        <WizCard p="no">
+        <WizCard p="no" id={id ? `date-range-picker-popup-${id}` : undefined}>
           <div className={styles.popupStyle}>
             {selectBoxOptions && (
               <div className={styles.popupHeaderStyle}>


### PR DESCRIPTION
#1518 

## 概要
DatePickerとDateRangePickerのポップアップ要素に動的なIDを付与できるようになりました。

## 変更内容
- ReactとVueの両方のDatePickerコンポーネントで、親からidが渡された場合にポップアップ要素にIDを設定
- IDの形式: `{component-name}-popup-{id}`
  - DatePicker: `date-picker-popup-{id}`
  - DateRangePicker: `date-range-picker-popup-{id}`

## 実装詳細

### React
- propsから`id`を取得し、ポップアップのdiv要素に条件付きで設定

### Vue
- `useAttrs()`を使用して親から渡されたid属性を取得
- `attrs.id`でアクセスし、同様の形式でポップアップ要素に設定

## テスト
- [x] ReactのDatePickerでIDが正しく設定される
- [x] ReactのDateRangePickerでIDが正しく設定される
- [x] VueのDatePickerでIDが正しく設定される
- [x] VueのDateRangePickerでIDが正しく設定される
- [x] IDが渡されない場合はundefinedになる

🤖 Generated with [Claude Code](https://claude.ai/code)