### PR TITLE
feat: CardにBorderStyleプロパティを追加

### DIFF
--- a/.changeset/cruel-carrots-taste.md
+++ b/.changeset/cruel-carrots-taste.md
@@ -1,0 +1,7 @@
+---
+"@wizleap-inc/wiz-ui-react": minor
+"@wizleap-inc/wiz-ui-next": minor
+"@wizleap-inc/wiz-ui-styles": minor
+---
+
+Feat: CardにBorderStyleプロパティを追加

--- a/packages/styles/bases/card.css.ts
+++ b/packages/styles/bases/card.css.ts
@@ -1,4 +1,4 @@
-import { style } from "@vanilla-extract/css";
+import { style, styleVariants } from "@vanilla-extract/css";
 import { THEME } from "@wizleap-inc/wiz-ui-constants";
 
 export const cardStyle = style({
@@ -15,9 +15,14 @@ export const cardShadowStyle = style({
   boxShadow: THEME.shadow.md,
 });
 
-export const cardBorderStyle = style({
+const cardBorderBase = style({
   borderWidth: "1px",
-  borderStyle: "solid",
+});
+
+export const cardBorderStyle = styleVariants({
+  solid: [cardBorderBase, { borderStyle: "solid" }],
+  dashed: [cardBorderBase, { borderStyle: "dashed" }],
+  dotted: [cardBorderBase, { borderStyle: "dotted" }],
 });
 
 export const cardFitStyle = style({

--- a/packages/wiz-ui-next/src/components/base/card/card.stories.ts
+++ b/packages/wiz-ui-next/src/components/base/card/card.stories.ts
@@ -40,6 +40,10 @@ export default {
     border: {
       control: { type: "boolean" },
     },
+    borderStyle: {
+      control: { type: "select" },
+      options: ["solid", "dashed", "dotted"],
+    },
     align: {
       control: { type: "select" },
       options: ["start", "center", "end"],
@@ -113,6 +117,29 @@ export const BorderColor = Template.bind({});
 BorderColor.args = {
   border: true,
   borderColor: "red.500",
+};
+
+export const BorderStyle = Template.bind({});
+BorderStyle.args = {
+  border: true,
+  borderStyle: "dashed",
+};
+BorderStyle.parameters = {
+  docs: {
+    description: {
+      story:
+        "`borderStyle` を指定することができます。選択肢は `solid`, `dashed`, `dotted` の中から選択できます。",
+    },
+    source: {
+      code: `
+<template>
+  <WizCard border borderStyle="dashed">
+    defaultスロット
+  </WizCard>
+</template>
+      `,
+    },
+  },
 };
 
 export const Align = Template.bind({});

--- a/packages/wiz-ui-next/src/components/base/card/card.vue
+++ b/packages/wiz-ui-next/src/components/base/card/card.vue
@@ -5,7 +5,7 @@
       fit && cardFitStyle,
       hexpand && cardHexpandStyle,
       shadow && cardShadowStyle,
-      border && cardBorderStyle,
+      border && cardBorderStyle[borderStyle],
       px && paddingXStyle[px],
       py && paddingYStyle[py],
       !px && !py && paddingStyle[p],
@@ -99,6 +99,11 @@ defineProps({
     type: String as PropType<ColorKeys>,
     required: false,
     default: "gray.400",
+  },
+  borderStyle: {
+    type: String as PropType<"solid" | "dashed" | "dotted">,
+    required: false,
+    default: "solid",
   },
   align: {
     type: String as PropType<"start" | "center" | "end" | "stretch">,

--- a/packages/wiz-ui-react/src/components/base/card/components/card.tsx
+++ b/packages/wiz-ui-react/src/components/base/card/components/card.tsx
@@ -24,6 +24,7 @@ type Props = BaseProps & {
   shadow?: boolean;
   border?: boolean;
   borderColor?: ColorKeys;
+  borderStyle?: "solid" | "dashed" | "dotted";
   align?: "start" | "center" | "end" | "stretch";
   fit?: boolean;
   hexpand?: boolean;
@@ -54,6 +55,7 @@ const Card = ({
   subHeaderArea,
   footerArea,
   borderColor = "gray.400",
+  borderStyle = "solid",
   ...props
 }: Props) => {
   return (
@@ -65,7 +67,7 @@ const Card = ({
         fit && styles.cardFitStyle,
         hexpand && styles.cardHexpandStyle,
         shadow && styles.cardShadowStyle,
-        border && styles.cardBorderStyle,
+        border && styles.cardBorderStyle[borderStyle],
         px && paddingXStyle[px],
         py && paddingYStyle[py],
         !px && !py && paddingStyle[p],

--- a/packages/wiz-ui-react/src/components/base/card/stories/card.stories.tsx
+++ b/packages/wiz-ui-react/src/components/base/card/stories/card.stories.tsx
@@ -32,6 +32,10 @@ const meta: Meta<typeof WizCard> = {
     border: {
       control: { type: "boolean" },
     },
+    borderStyle: {
+      control: { type: "select" },
+      options: ["solid", "dashed", "dotted"],
+    },
     align: {
       control: { type: "select" },
       options: ["start", "center", "end"],
@@ -101,6 +105,25 @@ export const borderColor: Story = {
     },
   },
 };
+
+export const BorderStyle: Story = {
+  args: {
+    border: true,
+    borderStyle: "dashed",
+  },
+  render: (args) => {
+    return <WizCard {...args}>Card の Body</WizCard>;
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`borderStyle` を指定することができます。選択肢は `solid`, `dashed`, `dotted` の中から選択できます。",
+      },
+    },
+  },
+};
+
 export const Align: Story = {
   args: {
     align: "center",


### PR DESCRIPTION
resolve: #1576

Cardコンポーネントに、BorderStyle( solid, dashed, dotted)を渡せるようにしました。
その他の選択肢はそれだけで使うことはないと思うので一旦除外してます。
doubleなどが必要に慣れば再度追加する