### PR TITLE
feat(accordion): プロパティ追加 iconWeight, iconColor, align between support

### DIFF
--- a/.changeset/twelve-teeth-grab.md
+++ b/.changeset/twelve-teeth-grab.md
@@ -1,0 +1,6 @@
+---
+"@wizleap-inc/wiz-ui-react": minor
+"@wizleap-inc/wiz-ui-next": minor
+---
+
+Feat: アコーディオンにiconWeightとiconColorを追加

--- a/packages/wiz-ui-next/src/components/base/accordion/accordion.stories.ts
+++ b/packages/wiz-ui-next/src/components/base/accordion/accordion.stories.ts
@@ -18,11 +18,19 @@ export default {
     },
     align: {
       control: { type: "select" },
-      options: ["start", "center", "end"],
+      options: ["start", "center", "end", "between"],
     },
     iconPosition: {
       control: { type: "select" },
       options: ["left", "right"],
+    },
+    iconWeight: {
+      control: { type: "select" },
+      options: ["normal", "bold"],
+    },
+    iconColor: {
+      control: { type: "select" },
+      options: COLOR_MAP_ACCESSORS,
     },
   },
 } as Meta<typeof WizAccordion>;
@@ -111,4 +119,14 @@ Align.args = {
 export const IconPosition = Template.bind({});
 IconPosition.args = {
   iconPosition: "left",
+};
+
+export const IconWeight = Template.bind({});
+IconWeight.args = {
+  iconWeight: "bold",
+};
+
+export const IconColor = Template.bind({});
+IconColor.args = {
+  iconColor: "green.800",
 };

--- a/packages/wiz-ui-next/src/components/base/accordion/accordion.vue
+++ b/packages/wiz-ui-next/src/components/base/accordion/accordion.vue
@@ -4,12 +4,17 @@
     :style="{ width }"
     :open="isOpen || isAnimating"
   >
+    <!-- align-betweenはテキストとアイコンの間隔のためのものなのでstartに変換する -->
     <summary
-      :class="[accordionSummaryStyle, accordionSummaryAlignStyle[align]]"
+      :class="[
+        accordionSummaryStyle,
+        accordionSummaryAlignStyle[align === 'between' ? 'start' : align],
+      ]"
       @click="onClick"
     >
       <WizHStack
         align="center"
+        :width="align === 'between' ? '100%' : 'auto'"
         justify="between"
         :reverse="iconPosition === 'left'"
         gap="xs2"
@@ -24,8 +29,8 @@
         </div>
         <WizIcon
           size="xl2"
-          :icon="WizIExpandMore"
-          :color="fontColor"
+          :icon="expandIcon"
+          :color="iconColor || fontColor"
           :class="[
             accordionExpandIconStyle,
             isOpen && accordionRotateIconStyle,
@@ -55,10 +60,10 @@ import {
   backgroundStyle,
   colorStyle,
 } from "@wizleap-inc/wiz-ui-styles/commons";
-import { PropType, nextTick, ref } from "vue";
+import { PropType, computed, nextTick, ref } from "vue";
 
 import { WizHStack, WizIcon } from "@/components";
-import { WizIExpandMore } from "@/components/icons";
+import { WizIExpandMore, WizIExpandMoreBold } from "@/components/icons";
 
 import {
   ANIMATION_CONFIGURATION,
@@ -96,7 +101,7 @@ const props = defineProps({
     default: "gray.600",
   },
   align: {
-    type: String as PropType<"start" | "center" | "end">,
+    type: String as PropType<"start" | "center" | "end" | "between">,
     required: false,
     default: "center",
   },
@@ -104,6 +109,15 @@ const props = defineProps({
     type: String as PropType<"left" | "right">,
     required: false,
     default: "right",
+  },
+  iconWeight: {
+    type: String as PropType<"normal" | "bold">,
+    required: false,
+    default: "normal",
+  },
+  iconColor: {
+    type: String as PropType<ColorKeys>,
+    required: false,
   },
 });
 
@@ -114,6 +128,10 @@ const emit = defineEmits<Emit>();
 
 const contentRef = ref<HTMLElement | undefined>();
 const isAnimating = ref(false);
+
+const expandIcon = computed(() => {
+  return props.iconWeight === "bold" ? WizIExpandMoreBold : WizIExpandMore;
+});
 
 const onClick = (event: MouseEvent) => {
   event.preventDefault();

--- a/packages/wiz-ui-react/src/components/base/accordion/components/accordion.tsx
+++ b/packages/wiz-ui-react/src/components/base/accordion/components/accordion.tsx
@@ -7,7 +7,12 @@ import {
 import clsx from "clsx";
 import { FC, ReactNode, ComponentPropsWithoutRef } from "react";
 
-import { WizHStack, WizIExpandMore, WizIcon } from "@/components";
+import {
+  WizHStack,
+  WizIExpandMore,
+  WizIExpandMoreBold,
+  WizIcon,
+} from "@/components";
 
 import { useToggleAnimation } from "./use-toggle-animation";
 
@@ -18,8 +23,10 @@ type Props = Omit<ComponentPropsWithoutRef<"details">, "onToggle"> & {
   width?: string;
   bgColor?: ColorKeys;
   fontColor?: ColorKeys;
-  align?: "start" | "center" | "end";
+  align?: "start" | "center" | "end" | "between";
   iconPosition?: "left" | "right";
+  iconWeight?: "normal" | "bold";
+  iconColor?: ColorKeys;
   children?: ReactNode;
   onToggle?: () => void;
 };
@@ -35,12 +42,17 @@ const Accordion: FC<Props> = ({
   fontColor = "gray.600",
   align = "center",
   iconPosition = "right",
+  iconWeight = "normal",
+  iconColor,
   children,
   onToggle,
   ...props
 }) => {
   const { isActuallyOpen, isAnimating, contentRef } =
     useToggleAnimation(isOpen);
+
+  const expandIcon =
+    iconWeight === "bold" ? WizIExpandMoreBold : WizIExpandMore;
 
   return (
     <details
@@ -56,7 +68,9 @@ const Accordion: FC<Props> = ({
       <summary
         className={clsx(
           styles.accordionSummaryStyle,
-          styles.accordionSummaryAlignStyle[align]
+          styles.accordionSummaryAlignStyle[
+            align === "between" ? "start" : align
+          ]
         )}
         onClick={(e) => {
           e.preventDefault();
@@ -71,6 +85,7 @@ const Accordion: FC<Props> = ({
             colorStyle[fontColor],
             bgColor && backgroundStyle[bgColor]
           )}
+          style={{ width: align === "between" ? "100%" : "auto" }}
         >
           <WizHStack
             align="center"
@@ -85,7 +100,11 @@ const Accordion: FC<Props> = ({
                 isOpen && styles.accordionRotateIconStyle
               )}
             >
-              <WizIcon icon={WizIExpandMore} size="xl2" color={fontColor} />
+              <WizIcon
+                icon={expandIcon}
+                size="xl2"
+                color={iconColor || fontColor}
+              />
             </div>
           </WizHStack>
         </div>

--- a/packages/wiz-ui-react/src/components/base/accordion/stories/accordion.stories.tsx
+++ b/packages/wiz-ui-react/src/components/base/accordion/stories/accordion.stories.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import { Meta, StoryObj } from "@storybook/react";
+import { COLOR_MAP_ACCESSORS } from "@wizleap-inc/wiz-ui-constants";
 import { useState } from "react";
 
 import { WizAccordion } from "../components";
@@ -8,13 +9,29 @@ const meta: Meta<typeof WizAccordion> = {
   title: "Base/Accordion",
   component: WizAccordion,
   argTypes: {
+    bgColor: {
+      control: { type: "select" },
+      options: COLOR_MAP_ACCESSORS,
+    },
+    fontColor: {
+      control: { type: "select" },
+      options: COLOR_MAP_ACCESSORS,
+    },
     align: {
       control: { type: "select" },
-      options: ["start", "center", "end"],
+      options: ["start", "center", "end", "between"],
     },
     iconPosition: {
       control: { type: "select" },
       options: ["left", "right"],
+    },
+    iconWeight: {
+      control: { type: "select" },
+      options: ["normal", "bold"],
+    },
+    iconColor: {
+      control: { type: "select" },
+      options: COLOR_MAP_ACCESSORS,
     },
   },
 };
@@ -96,5 +113,19 @@ export const IconPosition: Story = {
   ...Template,
   args: {
     iconPosition: "left",
+  },
+};
+
+export const IconWeight: Story = {
+  ...Template,
+  args: {
+    iconWeight: "bold",
+  },
+};
+
+export const IconColor: Story = {
+  ...Template,
+  args: {
+    iconColor: "green.800",
   },
 };


### PR DESCRIPTION
close https://github.com/Wizleap-Inc/wiz-ui/issues/1600
## 概要
Accordionコンポーネントに以下をつか
- `iconWeight`
- `iconColor` 
- `align=between`

## 実装の注意点
`align="between"` の実装は、ユーザービリティを優先した実用的なアプローチを採用しています:
- 内部的には `align="between"` を `align="start"` に変換してsummary要素に適用
- `WizHStack` の幅を `100%` に設定することで、space-between の配置を実現
- この実装は一見変則的に見えるかもしれませんが、ユーザーに対してテキストとアイコンを左右に配置するという意図を明確に表現できる直感的なAPIを提供します