### PR TITLE
Fix(VoiceInput): 背景色が一部transparentだったので白に統一

### DIFF
--- a/.changeset/spotty-parks-behave.md
+++ b/.changeset/spotty-parks-behave.md
@@ -1,0 +1,5 @@
+---
+"@wizleap-inc/wiz-ui-styles": minor
+---
+
+Fix(VoiceInput): 背景色が一部transparentだったので白に統一

--- a/packages/styles/customs/voice-input.css.ts
+++ b/packages/styles/customs/voice-input.css.ts
@@ -12,6 +12,7 @@ export const voiceInputStyle = style({
   justifyContent: "space-between",
   alignItems: "end",
   gap: THEME.spacing.xs,
+  backgroundColor: THEME.color.white[800],
 });
 
 export const voiceInputExpandStyle = style({


### PR DESCRIPTION
resolve: #1609 

Before
<img width="278" height="107" alt="スクリーンショット 2025-12-08 19 00 06" src="https://github.com/user-attachments/assets/ca91659e-49ff-4497-bcc4-b84ebb96d98d" />

After
<img width="281" height="104" alt="スクリーンショット 2025-12-08 18 59 32" src="https://github.com/user-attachments/assets/6aebb79b-4f5b-45ec-b83d-b652e583bd7c" />
