### PR TITLE
refactor(navigation-item): linkAttrsを使ってリンク属性を整理

### DIFF
--- a/.changeset/major-weeks-deny.md
+++ b/.changeset/major-weeks-deny.md
@@ -1,0 +1,5 @@
+---
+"@wizleap-inc/wiz-ui-next": minor
+---
+
+Feat: サイドメニューを別タブで開けるようにする

--- a/packages/wiz-ui-next/src/components/base/navigation/item.vue
+++ b/packages/wiz-ui-next/src/components/base/navigation/item.vue
@@ -4,9 +4,7 @@
       <div ref="navItemRef" @click="navItemOnClick">
         <component
           :is="disabled || isExternalLink ? 'a' : 'router-link'"
-          :to="!disabled && !isExternalLink ? to : undefined"
-          :href="!disabled && isExternalLink ? to : undefined"
-          :target="!disabled && isExternalLink ? '_blank' : undefined"
+          v-bind="linkAttrs"
           :class="[
             navigationItemStyle,
             disabled
@@ -134,6 +132,17 @@ const emit = defineEmits<{
 }>();
 
 const navItemRef = ref<HTMLElement>();
+
+const linkAttrs = computed(() => {
+  if (props.disabled) return {};
+
+  if (isExternalLink.value) {
+    return { href: props.to, target: "_blank" };
+  }
+
+  // router-link 用 (toが空文字列の場合は#を返す)
+  return { to: props.to };
+});
 
 const existPopup = computed(() => props.buttons && props.buttons?.length > 0);
 const navItemOnClick = () => emit("toggle", !props.isOpen);


### PR DESCRIPTION
issue: #1622 

## Summary
- NavigationItemで`to`と`href`が同時に指定されることで発生していた属性の競合を解消
- `linkAttrs` computedを追加し、コンポーネントの種類に応じて適切な属性のみを渡すように修正

## 背景
以前の実装では、`router-link`に対しても`:to`と`:href`の両方が渡されており、属性が競合して別タブで開けない問題があった。

## 変更内容
- `linkAttrs` computed propertyを追加
- disabled / 外部リンク / 内部リンクの場合で適切な属性のみを返すように修正
- `v-bind="linkAttrs"`で属性をまとめてバインド

## 既知の問題
- `WizPopupButtonGroup`内のボタンも同様の問題を抱えており、別タブで開けない
  - 現状は`onClick`で`router.push`を呼んでいるだけなので、右クリック→新しいタブで開く、Ctrl+クリック、中クリックなどに対応していない
  - 将来的には`PopupButtonOption`に`to`プロパティを追加し、`<a>`タグとして扱うことで解決できる可能性がある

## Test plan
- [ ] NavigationItemで外部リンクを別タブで開けることを確認
- [ ] NavigationItemで内部リンクが正常に動作することを確認
- [ ] disabledの場合にリンクが無効になることを確認