### PR TITLE
feat: DatePickerの適用ボタンを削除し日付選択時に即時適用

### DIFF
--- a/.changeset/curly-donuts-applaud.md
+++ b/.changeset/curly-donuts-applaud.md
@@ -1,0 +1,6 @@
+---
+"@wizleap-inc/wiz-ui-next": minor
+"@wizleap-inc/wiz-ui-react": minor
+---
+
+DatePicker の適用・キャンセルボタンを削除し、日付を選択した瞬間に値が適用されるように変更

--- a/packages/wiz-ui-next/src/components/base/inputs/date-picker/date-picker.stories.ts
+++ b/packages/wiz-ui-next/src/components/base/inputs/date-picker/date-picker.stories.ts
@@ -300,6 +300,60 @@ Test.play = async ({ canvasElement }) => {
   await userEvent.tab();
 };
 
+export const TestMonthNavigation: StoryFn<typeof WizDatepicker> = (args) => ({
+  components: { WizDatepicker, WizHStack },
+  setup() {
+    const date = ref<Date | null>(new Date(2000, 0, 1));
+    const isOpen = ref(true);
+    const setIsOpen = (value: boolean) => (isOpen.value = value);
+    return { args, date, isOpen, setIsOpen };
+  },
+  template: `
+    <WizDatepicker
+      v-bind="args"
+      v-model="date"
+      :isOpen="isOpen"
+      @update:modelValue="args.onClick"
+      @update:isOpen="setIsOpen"
+    />
+  `,
+});
+TestMonthNavigation.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  const button = canvas.getByLabelText(ARIA_LABELS.DATE_PICKER_INPUT);
+  await userEvent.click(button);
+  await waitFor(() => expect(button).toHaveFocus());
+
+  const body = within(canvasElement.ownerDocument.body);
+  const initialDate = new Date(2000, 0, 1);
+  const prevMonth = new Date(2000, -1, 1);
+  const nextMonth = new Date(2000, 1, 1);
+
+  // 月セレクターのPrevを1回押して操作月を1ヶ月前にする
+  const monthSelectorPrev = body.getByLabelText(
+    ARIA_LABELS.MONTH_SELECTOR_PREV
+  );
+  await userEvent.click(monthSelectorPrev);
+  await waitFor(() =>
+    expect(body.getByText(_formatDateJpMonth(prevMonth))).toBeTruthy()
+  );
+
+  // 月セレクターのNextを2回押して操作月を1ヶ月後にする
+  const monthSelectorNext = body.getByLabelText(
+    ARIA_LABELS.MONTH_SELECTOR_NEXT
+  );
+  await userEvent.click(monthSelectorNext);
+  await userEvent.click(monthSelectorNext);
+  await waitFor(() =>
+    expect(body.getByText(_formatDateJpMonth(nextMonth))).toBeTruthy()
+  );
+
+  // 月を移動してもInputの値は変わらない（適用されない）ことを確認
+  await waitFor(() =>
+    expect(button.textContent).toBe(_formatDateJp(initialDate))
+  );
+};
+
 export const IsDirectionFixed = Template.bind({});
 IsDirectionFixed.args = {
   modelValue: null,

--- a/packages/wiz-ui-next/src/components/base/inputs/date-picker/date-picker.stories.ts
+++ b/packages/wiz-ui-next/src/components/base/inputs/date-picker/date-picker.stories.ts
@@ -258,35 +258,25 @@ Test.play = async ({ canvasElement }) => {
 
   // その月の15日を選択
   const body = within(canvasElement.ownerDocument.body);
-  const initialDate = new Date(date.getFullYear(), date.getMonth(), 1);
   const clickDate = new Date(date.getFullYear(), date.getMonth(), 15);
   const pastClickDate = new Date(date.getFullYear(), date.getMonth() - 1, 15);
   const clickDateEl = body.getByLabelText(_formatDateJp(clickDate));
   await userEvent.click(clickDateEl);
-  // 選択済みというラベルがついていることを確認
-  await waitFor(() =>
-    expect(clickDateEl).toHaveAttribute(
-      "aria-label",
-      `${_formatDateJp(clickDate)}-選択済み`
-    )
-  );
 
-  // クリックした段階ではまだInputに反映されていないこと
-  await waitFor(() =>
-    expect(button.textContent).toBe(_formatDateJp(initialDate))
-  );
-
-  // 適用ボタンをクリック
-  const applyButton = body.getByText(ARIA_LABELS.APPLY);
-  await userEvent.click(applyButton);
-
-  // Input内が選択した日付になることを確認
+  // クリックした瞬間にInput内が選択した日付になることを確認
   await waitFor(() =>
     expect(button.textContent).toBe(_formatDateJp(clickDate))
   );
 
   // カレンダー再オープン
   await userEvent.click(button);
+
+  // 選択済みというラベルがついていることを確認
+  await waitFor(() =>
+    expect(
+      body.getByLabelText(`${_formatDateJp(clickDate)}-選択済み`)
+    ).toBeTruthy()
+  );
 
   // 月セレクターのPrevを1回押して操作月を1ヶ月前にする
   const monthSelectorPrev = body.getByLabelText(
@@ -301,38 +291,12 @@ Test.play = async ({ canvasElement }) => {
   // その月の15日を選択
   const pastDay = body.getByLabelText(_formatDateJp(pastClickDate));
   await userEvent.click(pastDay);
-  // 選択済みというラベルがついていることを確認
-  await waitFor(() =>
-    expect(pastDay).toHaveAttribute(
-      "aria-label",
-      `${_formatDateJp(pastClickDate)}-選択済み`
-    )
-  );
 
-  // Input内が選択した日付になることを確認
-  await waitFor(() =>
-    expect(button.textContent).toBe(_formatDateJp(new Date(clickDate)))
-  );
-
-  // 適用ボタンをクリック
-  await userEvent.click(applyButton);
-
-  // Input内が選択した日付になることを確認
+  // クリックした瞬間にInput内が選択した日付になることを確認
   await waitFor(() =>
     expect(button.textContent).toBe(_formatDateJp(new Date(pastClickDate)))
   );
 
-  // 月セレクターのNextを1回押して操作月を1ヶ月後にする
-  const monthSelectorNext = body.getByLabelText(
-    ARIA_LABELS.MONTH_SELECTOR_NEXT
-  );
-  await userEvent.click(monthSelectorNext);
-  const currentMonthDisplay = await body.findByText(
-    _formatDateJpMonth(clickDate)
-  );
-  await waitFor(() => expect(currentMonthDisplay).toBeTruthy());
-
-  await userEvent.click(button);
   await userEvent.tab();
 };
 

--- a/packages/wiz-ui-next/src/components/base/inputs/date-picker/date-picker.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/date-picker/date-picker.vue
@@ -110,10 +110,10 @@
         </WizHStack>
         <WizCalendar
           :active-dates="
-            tempDate
+            calendarValue
               ? [
                   {
-                    date: tempDate,
+                    date: calendarValue,
                     state: 'primary',
                   },
                 ]
@@ -125,15 +125,6 @@
           :_today="_today || new Date()"
           @click="handleClickCalendar"
         />
-        <WizDivider color="gray.300" />
-        <WizHStack p="sm" gap="sm" justify="end">
-          <WizTextButton variant="sub" @click="onClose">
-            {{ ARIA_LABELS.CANCEL }}
-          </WizTextButton>
-          <WizTextButton @click="onSubmit">
-            {{ ARIA_LABELS.APPLY }}
-          </WizTextButton>
-        </WizHStack>
       </div>
     </WizPopup>
   </WizPopupContainer>
@@ -160,13 +151,11 @@ import { PropType, computed, inject, ref, useAttrs } from "vue";
 
 import {
   WizCalendar,
-  WizDivider,
   WizHStack,
   WizIcon,
   WizPopup,
   WizPopupContainer,
   WizText,
-  WizTextButton,
   WizVStack,
 } from "@/components";
 import {
@@ -261,7 +250,6 @@ const defaultCurrentMonth = props.modelValue || new Date();
 const currentMonth = ref(defaultCurrentMonth);
 
 const setIsOpen = (value: boolean) => emit("update:isOpen", value);
-const tempDate = ref(props.modelValue);
 
 const clickToNextMonth = (e: KeyboardEvent | MouseEvent) => {
   e.preventDefault();
@@ -327,24 +315,20 @@ const variant = computed(() => {
   return "default";
 });
 
-const handleClickCalendar = (date: Date) => (tempDate.value = date);
+const handleClickCalendar = (date: Date) => {
+  calendarValue.value = date;
+  setIsOpen(false);
+};
 
 const onClickCancel = (e: MouseEvent) => {
   e.stopPropagation();
-  tempDate.value = null;
   currentMonth.value = new Date(defaultCurrentMonth);
   emit("update:modelValue", null);
   setIsOpen(false);
 };
 
 const onClose = () => {
-  tempDate.value = calendarValue.value;
   currentMonth.value = new Date(defaultCurrentMonth);
-  setIsOpen(false);
-};
-
-const onSubmit = () => {
-  calendarValue.value = tempDate.value;
   setIsOpen(false);
 };
 </script>

--- a/packages/wiz-ui-react/src/components/base/inputs/date-picker/components/date-picker.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/date-picker/components/date-picker.tsx
@@ -16,13 +16,7 @@ import {
   ComponentPropsWithoutRef,
 } from "react";
 
-import {
-  WizCalendar,
-  WizDivider,
-  WizPopup,
-  WizText,
-  WizTextButton,
-} from "@/components";
+import { WizCalendar, WizPopup, WizText } from "@/components";
 import { WizIcon } from "@/components/base/icon";
 import { WizHStack, WizVStack } from "@/components/base/stack";
 import { FormControlContext } from "@/components/custom/form/components/form-control-context";
@@ -89,8 +83,6 @@ const DatePicker: FC<Props> = ({
       )
     );
   };
-  const [tempDate, setTempDate] = useState(date);
-
   const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
     e.preventDefault();
     switch (e.key) {
@@ -128,20 +120,18 @@ const DatePicker: FC<Props> = ({
 
   const onCancel = (e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
-    setTempDate(null);
     setCurrentMonth(new Date());
     onChangeDate?.(null);
     setIsOpen(false);
   };
 
   const onClose = () => {
-    setTempDate(date);
     setCurrentMonth(date || new Date());
     setIsOpen(false);
   };
 
-  const onSubmit = () => {
-    onChangeDate?.(tempDate);
+  const onClickDate = (selected: Date) => {
+    onChangeDate?.(selected);
     setIsOpen(false);
   };
 
@@ -280,24 +270,13 @@ const DatePicker: FC<Props> = ({
             </div>
           </WizHStack>
           <WizCalendar
-            activeDates={
-              (tempDate && [{ date: tempDate, state: "primary" }]) || undefined
-            }
-            onClickDate={(date) => setTempDate(date)}
+            activeDates={(date && [{ date, state: "primary" }]) || undefined}
+            onClickDate={onClickDate}
             currentMonth={currentMonth}
             filledWeeks
             _today={_today || new Date()}
             disabledDate={disabledDate}
           />
-          <WizDivider color="gray.300" />
-          <WizHStack p="sm" gap="sm" justify="end">
-            <WizTextButton onClick={onClose} variant="sub">
-              {ARIA_LABELS.CANCEL}
-            </WizTextButton>
-            <WizTextButton onClick={onSubmit}>
-              {ARIA_LABELS.APPLY}
-            </WizTextButton>
-          </WizHStack>
         </div>
       </WizPopup>
     </>


### PR DESCRIPTION
## 概要
DatePicker から適用ボタンを削除し、カレンダーで日付をクリックした瞬間に値が適用されるように変更しました(React / Vue 両対応)。

## 変更内容
- **Vue** (`wiz-ui-next`) / **React** (`wiz-ui-react`) 共通:
  - 日付クリックで即座に `update:modelValue` / `onChangeDate` を発火し、ポップアップを閉じるように変更
  - 仮選択用の `tempDate` state と `onSubmit` を削除し、カレンダーのハイライトは実際の値を直接参照するように変更
  - フッター(適用・キャンセルボタン、区切り線)を削除
    - 即時適用のためキャンセルは「外側クリックで閉じる」と同義になるため
    - 入力欄右側の「×」(日付クリア)ボタンは従来どおり残しています
- Vue の `Test` ストーリーを即時適用の挙動に合わせて更新
- changeset 追加(両パッケージ minor)

※ `date-range-picker` の適用ボタンは本PRの対象外です。

## テスト
- [x] 型チェック: React ✅ / Vue は既存のアイコン関連エラーのみで date-picker 関連のエラーなし
- [x] ESLint: 変更ファイルすべてクリーン
- [x] Storybook インタラクションテスト: Vue 11/11 ✅ / React 11/11 ✅
- [x] Storybook 上で手動確認(即時適用・ポップアップクローズ・×ボタンによるクリア)