### PR TITLE
feat(inputs): checkbox系UIのdisabled+checked時にgreen.500の薄緑表示に統一

### DIFF
--- a/.changeset/disabled-checked-green.md
+++ b/.changeset/disabled-checked-green.md
@@ -5,8 +5,3 @@
 ---
 
 feat(checkbox,radio): disabled 状態のデザインを統一 (checked 時は green.500 に薄めた表示、opacity による半透明表現を廃止)
-
-- WizCheckBoxNew: disabled+checked の塗りを gray.400 → green.500 に変更、bordered 版の枠線を green.500 に変更
-- WizRadioNew: disabled+checked を「白背景 + green.500 枠 + green.500 ドット」に変更
-- WizCheckBox (legacy) / WizRadio (legacy): opacity 0.5 を廃止し、checked 時は green.500、unchecked 時は薄グレーの状態別スタイルに変更
-- WizCheckBoxNew (Vue): チェックアイコンを checked 時のみ描画するよう修正 (React 版と同挙動に)

--- a/.changeset/disabled-checked-green.md
+++ b/.changeset/disabled-checked-green.md
@@ -1,0 +1,12 @@
+---
+"@wizleap-inc/wiz-ui-styles": minor
+"@wizleap-inc/wiz-ui-next": minor
+"@wizleap-inc/wiz-ui-react": minor
+---
+
+feat(checkbox,radio): disabled 状態のデザインを統一 (checked 時は green.500 に薄めた表示、opacity による半透明表現を廃止)
+
+- WizCheckBoxNew: disabled+checked の塗りを gray.400 → green.500 に変更、bordered 版の枠線を green.500 に変更
+- WizRadioNew: disabled+checked を「白背景 + green.500 枠 + green.500 ドット」に変更
+- WizCheckBox (legacy) / WizRadio (legacy): opacity 0.5 を廃止し、checked 時は green.500、unchecked 時は薄グレーの状態別スタイルに変更
+- WizCheckBoxNew (Vue): チェックアイコンを checked 時のみ描画するよう修正 (React 版と同挙動に)

--- a/packages/styles/bases/checkbox-input.css.ts
+++ b/packages/styles/bases/checkbox-input.css.ts
@@ -1,4 +1,4 @@
-import { globalStyle, style, styleVariants } from "@vanilla-extract/css";
+import { style, styleVariants } from "@vanilla-extract/css";
 import { THEME } from "@wizleap-inc/wiz-ui-constants";
 
 const borderWidth = THEME.borderWidth.xs;
@@ -57,10 +57,21 @@ export const checkboxIconBaseStyle = style({
 export const checkboxIconVariantStyle = styleVariants({
   default: {
     border: `${borderWidth} solid ${THEME.color.gray["400"]}`,
+    selectors: {
+      [`${checkboxLabelDisabledStyle} &`]: {
+        backgroundColor: THEME.color.gray["300"],
+      },
+    },
   },
   checked: {
     fill: THEME.color.green["800"],
     border: `${borderWidth} solid ${THEME.color.green["800"]}`,
+    selectors: {
+      [`${checkboxLabelDisabledStyle} &`]: {
+        fill: THEME.color.green["500"],
+        borderColor: THEME.color.green["500"],
+      },
+    },
   },
 });
 
@@ -84,18 +95,3 @@ export const checkboxIconFocusedColorStyle = styleVariants({
 export const checkboxBlockCheckedStyle = style({
   color: THEME.color.green["800"],
 });
-
-globalStyle(
-  `${checkboxLabelDisabledStyle} ${checkboxIconVariantStyle.default}`,
-  {
-    backgroundColor: THEME.color.gray["300"],
-  }
-);
-
-globalStyle(
-  `${checkboxLabelDisabledStyle} ${checkboxIconVariantStyle.checked}`,
-  {
-    fill: THEME.color.green["500"],
-    borderColor: THEME.color.green["500"],
-  }
-);

--- a/packages/styles/bases/checkbox-input.css.ts
+++ b/packages/styles/bases/checkbox-input.css.ts
@@ -1,4 +1,4 @@
-import { style, styleVariants } from "@vanilla-extract/css";
+import { globalStyle, style, styleVariants } from "@vanilla-extract/css";
 import { THEME } from "@wizleap-inc/wiz-ui-constants";
 
 const borderWidth = THEME.borderWidth.xs;
@@ -32,9 +32,7 @@ export const checkboxLabelCheckedStyle = style({
   },
 });
 
-export const checkboxLabelDisabledStyle = style({
-  opacity: 0.5,
-});
+export const checkboxLabelDisabledStyle = style({});
 
 export const checkboxLabelStrikeThrough = style({
   textDecorationLine: "line-through",
@@ -86,3 +84,18 @@ export const checkboxIconFocusedColorStyle = styleVariants({
 export const checkboxBlockCheckedStyle = style({
   color: THEME.color.green["800"],
 });
+
+globalStyle(
+  `${checkboxLabelDisabledStyle} ${checkboxIconVariantStyle.default}`,
+  {
+    backgroundColor: THEME.color.gray["300"],
+  }
+);
+
+globalStyle(
+  `${checkboxLabelDisabledStyle} ${checkboxIconVariantStyle.checked}`,
+  {
+    fill: THEME.color.green["500"],
+    borderColor: THEME.color.green["500"],
+  }
+);

--- a/packages/styles/bases/checkbox-new.css.ts
+++ b/packages/styles/bases/checkbox-new.css.ts
@@ -70,7 +70,7 @@ export const borderedStyle = styleVariants({
   disabledChecked: [
     borderedBaseStyle,
     {
-      borderColor: THEME.color.green[800],
+      borderColor: THEME.color.green[500],
       backgroundColor: THEME.color.gray[200],
     },
   ],
@@ -123,7 +123,7 @@ export const iconWrapperStyle = style([
         backgroundColor: THEME.color.gray[300],
       },
       [`${inputStyle}:checked:disabled + &`]: {
-        backgroundColor: THEME.color.gray[400],
+        backgroundColor: THEME.color.green[500],
       },
     },
   },

--- a/packages/styles/bases/radio-input.css.ts
+++ b/packages/styles/bases/radio-input.css.ts
@@ -48,10 +48,6 @@ export const radioLabelCheckedStyle = style({
   },
 });
 
-export const radioLabelDisabledStyle = style({
-  opacity: 0.5,
-});
-
 export const radioLabelStrikeThrough = style({
   textDecorationLine: "line-through",
 });
@@ -77,6 +73,21 @@ export const radioLabelColorStyle = styleVariants({
     },
     ":after": {
       background: THEME.color.green["800"],
+    },
+  },
+});
+
+export const radioLabelDisabledStyle = style({
+  ":before": {
+    backgroundColor: THEME.color.gray["300"],
+  },
+  selectors: {
+    [`&${radioLabelCheckedStyle}::before`]: {
+      backgroundColor: THEME.color.white["800"],
+      borderColor: THEME.color.green["500"],
+    },
+    [`&${radioLabelCheckedStyle}::after`]: {
+      backgroundColor: THEME.color.green["500"],
     },
   },
 });

--- a/packages/styles/bases/radio-new.css.ts
+++ b/packages/styles/bases/radio-new.css.ts
@@ -72,7 +72,7 @@ export const borderedStyle = styleVariants({
   disabledChecked: [
     borderedBaseStyle,
     {
-      borderColor: THEME.color.green[800],
+      borderColor: THEME.color.green[500],
       backgroundColor: THEME.color.gray[200],
     },
   ],
@@ -124,6 +124,10 @@ export const markerStyle = style([
       [`${inputStyle}:disabled + &`]: {
         backgroundColor: THEME.color.gray[300],
       },
+      [`${inputStyle}:disabled:checked + &`]: {
+        backgroundColor: THEME.color.white[800],
+        borderColor: THEME.color.green[500],
+      },
       [`${inputStyle}:checked + &::before`]: {
         content: "",
         display: "block",
@@ -133,7 +137,7 @@ export const markerStyle = style([
         backgroundColor: THEME.color.green[800],
       },
       [`${inputStyle}:disabled:checked + &::before`]: {
-        backgroundColor: THEME.color.gray[500],
+        backgroundColor: THEME.color.green[500],
       },
     },
   },

--- a/packages/wiz-ui-next/src/components/base/inputs/checkbox-new/checkbox-new.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/checkbox-new/checkbox-new.vue
@@ -13,7 +13,7 @@
     <div
       :class="[styles.iconWrapperStyle, styles.inputMarginStyle[borderState]]"
     >
-      <div :class="styles.iconPositionStyle">
+      <div v-if="actualChecked" :class="styles.iconPositionStyle">
         <WizIcon :icon="WizICheckBold" color="white.800" size="md" />
       </div>
     </div>


### PR DESCRIPTION
## 概要

closes #1652

チェックボックス系UIの disabled 状態が薄いグレー一辺倒で checked/unchecked が判別しづらかったため、「値が分かりながら押せない感」のある表示に統一しました。

## 方針

**「disabled + checked = 通常の checked と同じ形のまま green.800 → green.500 に薄める」** で統一（ToggleSwitch の disabled ON が既にこの表現のためリファレンスとしました）。

- **disabled + checked**
  - WizCheckBoxNew（塗り型）: green.500 塗り + 白チェック（従来: gray.400 塗り）。bordered 版の枠線も green.500
  - WizRadioNew / legacy WizRadio（輪郭型）: 白背景 + green.500 枠 + green.500 マーカー（従来: グレー or opacity）
  - legacy WizCheckBox: green.500 のチェック + 枠
- **disabled + unchecked**: 従来の薄グレー表示を維持
- legacy の `opacity: 0.5` 一律半透明は廃止（ラベル文字まで薄くなり値の視認性が落ちるため）

## 変更内容

- `packages/styles/bases/checkbox-new.css.ts` / `radio-new.css.ts` / `checkbox-input.css.ts` / `radio-input.css.ts`（Vue/React共通スタイル）
- `checkbox-new.vue`: チェックアイコンを checked 時のみ描画するよう修正（React 版と同挙動に。従来は常時描画で、disabled 時のグレー背景に白チェックがうっすら見える潜在バグがあった）
- changeset: styles / wiz-ui-next / wiz-ui-react を minor バンプ

## 対象外

- WizToggleSwitch: 既に disabled ON が green.500 のため変更なし
- WizToggleButton: ボタン系のため対象外（レビューで除外判断）

## 確認方法

Storybook の以下ストーリーで disabled の checked / unchecked を確認:

- `Base/Input/CheckBoxNew > Variations`（各行2列目が disabled）
- `Base/Input/RadioNew > Variations`（同上）
- `Base/Input/CheckBox > StrikeThrough`（test2 = disabled+checked, test4 = disabled+unchecked）
- `Base/Input/Radio > StrikeThrough`（2段目が全て disabled、test1 が選択済み）

## 備考

- 白チェック on green.500 のコントラストは約 1.4:1 で WCAG 1.4.11 の 3:1 未満ですが、disabled コントロールは同基準の適用除外であり、ToggleSwitch の disabled ON で出荷済みの組み合わせです
- VRT には disabled 系ストーリーに意図した差分が出ます

