### PR TITLE
feat(inputs): TimePickerにminuteIntervalプロパティを追加し1分単位の選択に対応

### DIFF
--- a/.changeset/timepicker-minute-interval.md
+++ b/.changeset/timepicker-minute-interval.md
@@ -1,0 +1,6 @@
+---
+"@wizleap-inc/wiz-ui-next": minor
+"@wizleap-inc/wiz-ui-react": minor
+---
+
+feat(TimePicker): minuteInterval プロパティを追加し、分の選択間隔を指定できるようにする（デフォルトは従来通り5分間隔）

--- a/packages/wiz-ui-next/src/components/base/inputs/timepicker/time-picker.stories.ts
+++ b/packages/wiz-ui-next/src/components/base/inputs/timepicker/time-picker.stories.ts
@@ -23,6 +23,9 @@ export default {
     isDirectionFixed: {
       control: { type: "boolean" },
     },
+    minuteInterval: {
+      control: { type: "number" },
+    },
   },
 } as Meta<typeof WizTimePicker>;
 
@@ -52,4 +55,10 @@ Expand.args = {
 export const IsDirectionFixed = Template.bind({});
 IsDirectionFixed.args = {
   isDirectionFixed: true,
+};
+
+// 1分間隔
+export const MinuteInterval = Template.bind({});
+MinuteInterval.args = {
+  minuteInterval: 1,
 };

--- a/packages/wiz-ui-next/src/components/base/inputs/timepicker/time-picker.vue
+++ b/packages/wiz-ui-next/src/components/base/inputs/timepicker/time-picker.vue
@@ -156,6 +156,11 @@ const props = defineProps({
     required: false,
     default: false,
   },
+  minuteInterval: {
+    type: Number,
+    required: false,
+    default: 5,
+  },
 });
 
 const openTimepicker = ref(false);
@@ -163,8 +168,10 @@ const selectedHour = ref("");
 const selectedMinute = ref("");
 
 const hourOptions = [...Array(24).keys()].map((val) => String(val));
-const minuteOptions = [...Array(12)].map((_, index) =>
-  String(index * 5).padStart(2, "0")
+const minuteOptions = computed(() =>
+  [...Array(Math.ceil(60 / props.minuteInterval))].map((_, index) =>
+    String(index * props.minuteInterval).padStart(2, "0")
+  )
 );
 
 const toggleTimepicker = () => {

--- a/packages/wiz-ui-react/src/components/base/inputs/time-picker/components/time-picker.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/time-picker/components/time-picker.tsx
@@ -22,7 +22,7 @@ import {
 } from "@/components";
 import { FormControlContext } from "@/components/custom/form/components/form-control-context";
 
-import { HOURS, MINUTES, Time } from "../types/time";
+import { HOURS, Time } from "../types/time";
 
 type Props = Omit<ComponentPropsWithoutRef<"div">, "onChange"> & {
   time: Time | null;
@@ -31,6 +31,7 @@ type Props = Omit<ComponentPropsWithoutRef<"div">, "onChange"> & {
   disabled?: boolean;
   isDirectionFixed?: boolean;
   error?: boolean;
+  minuteInterval?: number;
   onChange?: (time: Time | null) => void;
 };
 
@@ -43,9 +44,14 @@ const TimePicker: FC<Props> = ({
   disabled = false,
   isDirectionFixed = false,
   error = false,
+  minuteInterval = 5,
   onChange,
   ...props
 }) => {
+  const minuteOptions = Array.from(
+    { length: Math.ceil(60 / minuteInterval) },
+    (_, i) => i * minuteInterval
+  );
   const anchor = useRef<HTMLDivElement | null>(null);
   const [isOpen, setIsOpen] = useState(false);
   const [isHover, setIsHover] = useState(false);
@@ -193,7 +199,7 @@ const TimePicker: FC<Props> = ({
                 nowrap
                 className={styles.timePickerScrollStyle}
               >
-                {MINUTES.map((option) => (
+                {minuteOptions.map((option) => (
                   <div
                     key={"mm" + option}
                     className={clsx([

--- a/packages/wiz-ui-react/src/components/base/inputs/time-picker/stories/time-picker.stories.tsx
+++ b/packages/wiz-ui-react/src/components/base/inputs/time-picker/stories/time-picker.stories.tsx
@@ -63,6 +63,20 @@ export const Expand: Story = {
   },
 };
 
+export const MinuteInterval: Story = {
+  args: {
+    minuteInterval: 1,
+  },
+  render: (args) => {
+    const [time, setTime] = useState<Time | null>(null);
+    return <WizTimePicker {...args} time={time} onChange={setTime} />;
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    fireEvent.click(canvas.getByRole("button"));
+  },
+};
+
 export const Error: Story = {
   args: {
     error: true,

--- a/packages/wiz-ui-react/src/components/base/inputs/time-picker/types/time.ts
+++ b/packages/wiz-ui-react/src/components/base/inputs/time-picker/types/time.ts
@@ -7,5 +7,5 @@ export const MINUTES = [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55] as const;
 
 export type Time = {
   hour: (typeof HOURS)[number];
-  minute: (typeof MINUTES)[number];
+  minute: number;
 };


### PR DESCRIPTION
# タスク

resolve: #1655

## 変更内容

TimePickerの分の選択間隔を指定できる `minuteInterval` プロパティを追加しました。デフォルトは従来通り5分間隔のため、既存の利用箇所への影響はありません（後方互換）。

- **WizTimePicker (wiz-ui-react)**
  - `minuteInterval` prop（デフォルト: 5）を追加し、分の選択肢を動的生成に変更
  - `Time` 型の `minute` を5の倍数のunion型から `number` に拡大（型を広げる方向のため後方互換）
- **WizTimePicker (wiz-ui-next)**
  - `minuteInterval` prop（デフォルト: 5）を追加し、`minuteOptions` をcomputedに変更
- 両パッケージのStorybookに1分間隔の `MinuteInterval` storyを追加
- changeset追加（両パッケージminor）

## 使い方

```tsx
// React
<WizTimePicker time={time} onChange={setTime} minuteInterval={1} />
```

```vue
<!-- Vue -->
<WizTimePicker v-model="value" :minute-interval="1" />
```

## 確認

- [x] tsc / vue-tsc の型チェック通過
- [x] eslint 通過

https://claude.ai/code/session_01KjZiso58xA3UTC8aQmdZsu