### PR TITLE
feat(progress-bar): rejected status追加 & label/annotationのスタイル指定を可能に

### DIFF
--- a/.changeset/progress-bar-label-annotation-style.md
+++ b/.changeset/progress-bar-label-annotation-style.md
@@ -1,0 +1,7 @@
+---
+"@wizleap-inc/wiz-ui-styles": patch
+"@wizleap-inc/wiz-ui-next": minor
+"@wizleap-inc/wiz-ui-react": minor
+---
+
+feat(progress-bar): WizProgressBar に labelColor / labelSize / annotationColor / annotationSize を追加。あわせて point と label / annotation の間に 4px の余白を追加

--- a/.changeset/progress-bar-per-item-style.md
+++ b/.changeset/progress-bar-per-item-style.md
@@ -1,0 +1,6 @@
+---
+"@wizleap-inc/wiz-ui-next": minor
+"@wizleap-inc/wiz-ui-react": minor
+---
+
+feat(progress-bar): ProgressItem ごとに labelColor / labelSize / annotationColor / annotationSize を個別指定可能に。指定がない場合は WizProgressBar 側の同名 prop の値にフォールバック

--- a/.changeset/progress-bar-rejected-status.md
+++ b/.changeset/progress-bar-rejected-status.md
@@ -1,0 +1,13 @@
+---
+"@wizleap-inc/wiz-ui-styles": minor
+"@wizleap-inc/wiz-ui-next": major
+"@wizleap-inc/wiz-ui-react": major
+---
+
+feat(progress-bar)!: rejected ステータスの追加と progress の型変更
+
+- `ProgressStatus` に `"rejected"`（赤の破線ボーダー・ピンク背景）を追加
+- `ProgressItem.progress` を `boolean` から `"active" | "inactive" | "rejected"` に変更（新しく `ProgressState` 型としてエクスポート）
+- `WizProgressLine` の props を `active: boolean` から `state: ProgressState` に変更
+
+BREAKING CHANGE: `progress: true` は `progress: "active"`、`progress: false` は `progress: "inactive"` に置き換えてください。`WizProgressLine` を直接使用している場合は `active` prop を `state` にリネームしてください。

--- a/packages/styles/bases/progress-bar.css.ts
+++ b/packages/styles/bases/progress-bar.css.ts
@@ -38,14 +38,16 @@ export const progressBarPointWrapperStyle = style({
 
 export const progressBarItemLabelStyle = style({
   position: "absolute",
-  bottom: `calc(${THEME.spacing.md} * -1)`,
+  top: "100%",
+  marginTop: THEME.spacing.xs2,
   left: "50%",
   transform: "translateX(-50%)",
 });
 
 export const progressBarItemAnnotationStyle = style({
   position: "absolute",
-  top: `calc(${THEME.spacing.md} * -1)`,
+  bottom: "100%",
+  marginBottom: THEME.spacing.xs2,
   left: "50%",
   transform: "translateX(-50%)",
   color: THEME.color.red[800],
@@ -66,6 +68,9 @@ export const progressLineBackgroundStyle = styleVariants({
   },
   active: {
     background: THEME.color.green[800],
+  },
+  rejected: {
+    background: THEME.color.red[800],
   },
 });
 
@@ -135,6 +140,13 @@ export const progressPointVariantStyle = styleVariants({
     position: "relative",
     ":before": {
       background: THEME.color.gray[300],
+    },
+  },
+  rejected: {
+    background: `repeating-conic-gradient(${THEME.color.red[800]} 0 calc(360deg / ${PROGRESS_POINT_DASH_NUM} / 2), ${THEME.color.red[300]} 0 calc(360deg / ${PROGRESS_POINT_DASH_NUM}))`,
+    position: "relative",
+    ":before": {
+      background: THEME.color.red[300],
     },
   },
 });

--- a/packages/styles/bases/progress-bar.css.ts
+++ b/packages/styles/bases/progress-bar.css.ts
@@ -38,16 +38,14 @@ export const progressBarPointWrapperStyle = style({
 
 export const progressBarItemLabelStyle = style({
   position: "absolute",
-  top: "100%",
-  marginTop: THEME.spacing.xs2,
+  top: `calc(100% + ${THEME.spacing.xs2})`,
   left: "50%",
   transform: "translateX(-50%)",
 });
 
 export const progressBarItemAnnotationStyle = style({
   position: "absolute",
-  bottom: "100%",
-  marginBottom: THEME.spacing.xs2,
+  bottom: `calc(100% + ${THEME.spacing.xs2})`,
   left: "50%",
   transform: "translateX(-50%)",
   color: THEME.color.red[800],

--- a/packages/wiz-ui-next/src/components/base/progress-bar/progress-bar.stories.ts
+++ b/packages/wiz-ui-next/src/components/base/progress-bar/progress-bar.stories.ts
@@ -1,4 +1,8 @@
 import { Meta, StoryFn } from "@storybook/vue3";
+import {
+  COLOR_MAP_ACCESSORS,
+  FONT_SIZE_ACCESSORS,
+} from "@wizleap-inc/wiz-ui-constants";
 
 import { WizProgressBar } from ".";
 
@@ -8,6 +12,22 @@ export default {
   argTypes: {
     content: {
       control: { type: "object" },
+    },
+    labelColor: {
+      control: { type: "select" },
+      options: COLOR_MAP_ACCESSORS,
+    },
+    labelSize: {
+      control: { type: "select" },
+      options: FONT_SIZE_ACCESSORS,
+    },
+    annotationColor: {
+      control: { type: "select" },
+      options: COLOR_MAP_ACCESSORS,
+    },
+    annotationSize: {
+      control: { type: "select" },
+      options: FONT_SIZE_ACCESSORS,
     },
   },
 } as Meta<typeof WizProgressBar>;
@@ -29,7 +49,14 @@ const STATUS = [
   "none",
   "pending",
   "dead",
+  "rejected",
 ] as const;
+
+const progressAt = (index: number): "active" | "inactive" | "rejected" => {
+  if ([1, 3, 4].includes(index)) return "active";
+  if (index === 6) return "rejected";
+  return "inactive";
+};
 
 export const Default = Template.bind({});
 Default.args = {
@@ -48,7 +75,7 @@ export const WithProgress = Template.bind({});
 WithProgress.args = {
   contents: STATUS.map((status, index) => ({
     status,
-    progress: [1, 3, 4].includes(index),
+    progress: progressAt(index),
   })),
 };
 
@@ -81,9 +108,42 @@ WithAll.args = {
   contents: STATUS.map((status, index) => ({
     status,
     value: index + 1,
-    progress: [1, 3, 4].includes(index),
+    progress: progressAt(index),
     tooltip: `Tooltip ${index + 1}`,
     label: `Label ${index + 1}`,
     annotation: `Annotation ${index + 1}`,
   })),
+};
+
+export const WithCustomLabel = Template.bind({});
+WithCustomLabel.args = {
+  contents: STATUS.map((status, index) => ({
+    status,
+    label: `Label ${index + 1}`,
+  })),
+  labelColor: "blue.800",
+  labelSize: "md",
+};
+
+export const WithCustomAnnotation = Template.bind({});
+WithCustomAnnotation.args = {
+  contents: STATUS.map((status, index) => ({
+    status,
+    annotation: `Annotation ${index + 1}`,
+  })),
+  annotationColor: "green.800",
+  annotationSize: "md",
+};
+
+export const WithCustomLabelAndAnnotation = Template.bind({});
+WithCustomLabelAndAnnotation.args = {
+  contents: STATUS.map((status, index) => ({
+    status,
+    label: `Label ${index + 1}`,
+    annotation: `Annotation ${index + 1}`,
+  })),
+  labelColor: "blue.800",
+  labelSize: "md",
+  annotationColor: "green.800",
+  annotationSize: "md",
 };

--- a/packages/wiz-ui-next/src/components/base/progress-bar/progress-bar.stories.ts
+++ b/packages/wiz-ui-next/src/components/base/progress-bar/progress-bar.stories.ts
@@ -147,3 +147,22 @@ WithCustomLabelAndAnnotation.args = {
   annotationColor: "green.800",
   annotationSize: "md",
 };
+
+export const WithPerItemCustomStyle = Template.bind({});
+WithPerItemCustomStyle.args = {
+  contents: STATUS.map((status, index) => ({
+    status,
+    label: `Label ${index + 1}`,
+    annotation: `Annotation ${index + 1}`,
+    ...(index === 1 && {
+      labelColor: "blue.800" as const,
+      labelSize: "md" as const,
+      annotationColor: "green.800" as const,
+      annotationSize: "md" as const,
+    }),
+    ...(index === 3 && {
+      labelColor: "purple.800" as const,
+      labelSize: "sm" as const,
+    }),
+  })),
+};

--- a/packages/wiz-ui-next/src/components/base/progress-bar/progress-bar.vue
+++ b/packages/wiz-ui-next/src/components/base/progress-bar/progress-bar.vue
@@ -11,25 +11,37 @@
         </template>
         <div :class="progressBarPointWrapperStyle">
           <span :class="progressBarItemAnnotationStyle">
-            <WizText font-size="xs2" color="red.800" white-space="nowrap">
+            <WizText
+              :font-size="annotationSize"
+              :color="annotationColor"
+              white-space="nowrap"
+            >
               {{ content.annotation }}
             </WizText>
           </span>
           <WizProgressPoint :status="content.status" :value="content.value" />
           <span :class="progressBarItemLabelStyle">
-            <WizText font-size="xs2" color="gray.600" white-space="nowrap">
+            <WizText
+              :font-size="labelSize"
+              :color="labelColor"
+              white-space="nowrap"
+            >
               {{ content.label }}
             </WizText>
           </span>
         </div>
       </WizTooltip>
-      <WizProgressLine :active="content.progress" :is-first="i === 0" />
+      <WizProgressLine :state="content.progress" :is-first="i === 0" />
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
+import {
+  ColorKeys,
+  ComponentName,
+  FontSizeKeys,
+} from "@wizleap-inc/wiz-ui-constants";
 import {
   progressBarStyle,
   progressBarItemStyle,
@@ -54,6 +66,26 @@ defineProps({
   contents: {
     type: Array as PropType<ProgressItem[]>,
     required: true,
+  },
+  labelColor: {
+    type: String as PropType<ColorKeys>,
+    required: false,
+    default: "gray.600",
+  },
+  labelSize: {
+    type: String as PropType<FontSizeKeys>,
+    required: false,
+    default: "xs2",
+  },
+  annotationColor: {
+    type: String as PropType<ColorKeys>,
+    required: false,
+    default: "red.800",
+  },
+  annotationSize: {
+    type: String as PropType<FontSizeKeys>,
+    required: false,
+    default: "xs2",
   },
 });
 </script>

--- a/packages/wiz-ui-next/src/components/base/progress-bar/progress-bar.vue
+++ b/packages/wiz-ui-next/src/components/base/progress-bar/progress-bar.vue
@@ -12,8 +12,8 @@
         <div :class="progressBarPointWrapperStyle">
           <span :class="progressBarItemAnnotationStyle">
             <WizText
-              :font-size="annotationSize"
-              :color="annotationColor"
+              :font-size="content.annotationSize ?? annotationSize"
+              :color="content.annotationColor ?? annotationColor"
               white-space="nowrap"
             >
               {{ content.annotation }}
@@ -22,8 +22,8 @@
           <WizProgressPoint :status="content.status" :value="content.value" />
           <span :class="progressBarItemLabelStyle">
             <WizText
-              :font-size="labelSize"
-              :color="labelColor"
+              :font-size="content.labelSize ?? labelSize"
+              :color="content.labelColor ?? labelColor"
               white-space="nowrap"
             >
               {{ content.label }}

--- a/packages/wiz-ui-next/src/components/base/progress-bar/progress-line.vue
+++ b/packages/wiz-ui-next/src/components/base/progress-bar/progress-line.vue
@@ -3,7 +3,7 @@
     class="wiz-progress-line"
     :class="[
       progressLineStyle,
-      progressLineBackgroundStyle[active ? 'active' : 'inactive'],
+      progressLineBackgroundStyle[state],
       progressLineWidthStyle[isFirst ? 'first' : 'default'],
     ]"
   />
@@ -16,15 +16,19 @@ import {
   progressLineBackgroundStyle,
   progressLineWidthStyle,
 } from "@wizleap-inc/wiz-ui-styles/bases/progress-bar.css";
+import { PropType } from "vue";
+
+import type { ProgressState } from "./types";
 
 defineOptions({
   name: ComponentName.ProgressLine,
 });
 
 defineProps({
-  active: {
-    type: Boolean,
+  state: {
+    type: String as PropType<ProgressState>,
     required: false,
+    default: "inactive",
   },
   isFirst: {
     type: Boolean,

--- a/packages/wiz-ui-next/src/components/base/progress-bar/progress-point.stories.ts
+++ b/packages/wiz-ui-next/src/components/base/progress-bar/progress-point.stories.ts
@@ -9,7 +9,15 @@ export default {
     status: {
       control: {
         type: "select",
-        options: ["done", "active", "inactive", "pending", "dead", "none"],
+        options: [
+          "done",
+          "active",
+          "inactive",
+          "pending",
+          "dead",
+          "none",
+          "rejected",
+        ],
       },
     },
     value: {
@@ -37,6 +45,7 @@ const MultipleTemplate: StoryFn<typeof WizProgressPoint> = (args) => ({
       <WizProgressPoint v-bind="args" status="pending"/>
       <WizProgressPoint v-bind="args" status="dead"/>
       <WizProgressPoint v-bind="args" status="none"/>
+      <WizProgressPoint v-bind="args" status="rejected"/>
     </div>
   `,
 });
@@ -69,6 +78,11 @@ Dead.args = {
 export const None = Template.bind({});
 None.args = {
   status: "none",
+};
+
+export const Rejected = Template.bind({});
+Rejected.args = {
+  status: "rejected",
 };
 
 export const WithValue = MultipleTemplate.bind({});

--- a/packages/wiz-ui-next/src/components/base/progress-bar/types.ts
+++ b/packages/wiz-ui-next/src/components/base/progress-bar/types.ts
@@ -4,13 +4,16 @@ export type ProgressStatus =
   | "inactive"
   | "none"
   | "pending"
-  | "dead";
+  | "dead"
+  | "rejected";
+
+export type ProgressState = "active" | "inactive" | "rejected";
 
 export interface ProgressItem {
   status: ProgressStatus;
   label?: string;
   annotation?: string;
   tooltip?: string;
-  progress?: boolean;
+  progress?: ProgressState;
   value?: number;
 }

--- a/packages/wiz-ui-next/src/components/base/progress-bar/types.ts
+++ b/packages/wiz-ui-next/src/components/base/progress-bar/types.ts
@@ -1,3 +1,5 @@
+import { ColorKeys, FontSizeKeys } from "@wizleap-inc/wiz-ui-constants";
+
 export type ProgressStatus =
   | "done"
   | "active"
@@ -16,4 +18,8 @@ export interface ProgressItem {
   tooltip?: string;
   progress?: ProgressState;
   value?: number;
+  labelColor?: ColorKeys;
+  labelSize?: FontSizeKeys;
+  annotationColor?: ColorKeys;
+  annotationSize?: FontSizeKeys;
 }

--- a/packages/wiz-ui-react/src/components/base/progress-bar/components/progress-bar.tsx
+++ b/packages/wiz-ui-react/src/components/base/progress-bar/components/progress-bar.tsx
@@ -1,4 +1,8 @@
-import { ComponentName } from "@wizleap-inc/wiz-ui-constants";
+import {
+  ColorKeys,
+  ComponentName,
+  FontSizeKeys,
+} from "@wizleap-inc/wiz-ui-constants";
 import * as styles from "@wizleap-inc/wiz-ui-styles/bases/progress-bar.css";
 import clsx from "clsx";
 import { FC } from "react";
@@ -14,9 +18,27 @@ import { WizProgressLine } from ".";
 
 type Props = BaseProps & {
   contents: ProgressItem[];
+  labelColor?: ColorKeys;
+  labelSize?: FontSizeKeys;
+  annotationColor?: ColorKeys;
+  annotationSize?: FontSizeKeys;
 };
 
-const ProgressBar: FC<Props> = ({ className, style, contents }) => {
+const ProgressBar: FC<Props> = ({
+  className,
+  style,
+  contents,
+  labelColor = "gray.600",
+  labelSize = "xs2",
+  annotationColor = "red.800",
+  annotationSize = "xs2",
+}) => {
+  const progressProps = {
+    labelColor,
+    labelSize,
+    annotationColor,
+    annotationSize,
+  };
   return (
     <div className={clsx(className, styles.progressBarStyle)} style={style}>
       {contents.map((content, index) => (
@@ -28,12 +50,12 @@ const ProgressBar: FC<Props> = ({ className, style, contents }) => {
         >
           {content.tooltip ? (
             <WizTooltip content={content.tooltip}>
-              <Progress content={content} />
+              <Progress content={content} {...progressProps} />
             </WizTooltip>
           ) : (
-            <Progress content={content} />
+            <Progress content={content} {...progressProps} />
           )}
-          <WizProgressLine active={content.progress} isFirst={index === 0} />
+          <WizProgressLine state={content.progress} isFirst={index === 0} />
         </div>
       ))}
     </div>

--- a/packages/wiz-ui-react/src/components/base/progress-bar/components/progress-line.tsx
+++ b/packages/wiz-ui-react/src/components/base/progress-bar/components/progress-line.tsx
@@ -4,18 +4,26 @@ import clsx from "clsx";
 import { FC } from "react";
 
 import { BaseProps } from "@/types";
+
+import type { ProgressState } from "../types";
+
 type Props = BaseProps & {
-  active?: boolean;
+  state?: ProgressState;
   isFirst: boolean;
 };
 
-const ProgressLine: FC<Props> = ({ className, style, active, isFirst }) => {
+const ProgressLine: FC<Props> = ({
+  className,
+  style,
+  state = "inactive",
+  isFirst,
+}) => {
   return (
     <span
       className={clsx(
         className,
         styles.progressLineStyle,
-        styles.progressLineBackgroundStyle[active ? "active" : "inactive"],
+        styles.progressLineBackgroundStyle[state],
         styles.progressLineWidthStyle[isFirst ? "first" : "default"]
       )}
       style={style}

--- a/packages/wiz-ui-react/src/components/base/progress-bar/components/progress.tsx
+++ b/packages/wiz-ui-react/src/components/base/progress-bar/components/progress.tsx
@@ -1,3 +1,4 @@
+import { ColorKeys, FontSizeKeys } from "@wizleap-inc/wiz-ui-constants";
 import * as styles from "@wizleap-inc/wiz-ui-styles/bases/progress-bar.css";
 
 import { WizText } from "@/components";
@@ -6,16 +7,34 @@ import { ProgressItem } from "../types";
 
 import { WizProgressPoint } from "./progress-point";
 
-export const Progress = ({ content }: { content: ProgressItem }) => (
+type Props = {
+  content: ProgressItem;
+  labelColor: ColorKeys;
+  labelSize: FontSizeKeys;
+  annotationColor: ColorKeys;
+  annotationSize: FontSizeKeys;
+};
+
+export const Progress = ({
+  content,
+  labelColor,
+  labelSize,
+  annotationColor,
+  annotationSize,
+}: Props) => (
   <div className={styles.progressBarPointWrapperStyle}>
     <span className={styles.progressBarItemAnnotationStyle}>
-      <WizText fontSize="xs2" color="red.800" whiteSpace="nowrap">
+      <WizText
+        fontSize={annotationSize}
+        color={annotationColor}
+        whiteSpace="nowrap"
+      >
         {content.annotation}
       </WizText>
     </span>
     <WizProgressPoint status={content.status} value={content.value} />
     <span className={styles.progressBarItemLabelStyle}>
-      <WizText fontSize="xs2" color="gray.600" whiteSpace="nowrap">
+      <WizText fontSize={labelSize} color={labelColor} whiteSpace="nowrap">
         {content.label}
       </WizText>
     </span>

--- a/packages/wiz-ui-react/src/components/base/progress-bar/components/progress.tsx
+++ b/packages/wiz-ui-react/src/components/base/progress-bar/components/progress.tsx
@@ -25,8 +25,8 @@ export const Progress = ({
   <div className={styles.progressBarPointWrapperStyle}>
     <span className={styles.progressBarItemAnnotationStyle}>
       <WizText
-        fontSize={annotationSize}
-        color={annotationColor}
+        fontSize={content.annotationSize ?? annotationSize}
+        color={content.annotationColor ?? annotationColor}
         whiteSpace="nowrap"
       >
         {content.annotation}
@@ -34,7 +34,11 @@ export const Progress = ({
     </span>
     <WizProgressPoint status={content.status} value={content.value} />
     <span className={styles.progressBarItemLabelStyle}>
-      <WizText fontSize={labelSize} color={labelColor} whiteSpace="nowrap">
+      <WizText
+        fontSize={content.labelSize ?? labelSize}
+        color={content.labelColor ?? labelColor}
+        whiteSpace="nowrap"
+      >
         {content.label}
       </WizText>
     </span>

--- a/packages/wiz-ui-react/src/components/base/progress-bar/stories/progress-bar.stories.tsx
+++ b/packages/wiz-ui-react/src/components/base/progress-bar/stories/progress-bar.stories.tsx
@@ -208,3 +208,24 @@ export const WithCustomLabelAndAnnotation: Story = {
     annotationSize: "md",
   },
 };
+
+export const WithPerItemCustomStyle: Story = {
+  args: {
+    contents: contents.map((content, index) => ({
+      id: content.id,
+      status: content.status,
+      label: content.label,
+      annotation: content.annotation,
+      ...(index === 1 && {
+        labelColor: "blue.800" as const,
+        labelSize: "md" as const,
+        annotationColor: "green.800" as const,
+        annotationSize: "md" as const,
+      }),
+      ...(index === 3 && {
+        labelColor: "purple.800" as const,
+        labelSize: "sm" as const,
+      }),
+    })),
+  },
+};

--- a/packages/wiz-ui-react/src/components/base/progress-bar/stories/progress-bar.stories.tsx
+++ b/packages/wiz-ui-react/src/components/base/progress-bar/stories/progress-bar.stories.tsx
@@ -1,4 +1,8 @@
 import { Meta, StoryObj } from "@storybook/react";
+import {
+  COLOR_MAP_ACCESSORS,
+  FONT_SIZE_ACCESSORS,
+} from "@wizleap-inc/wiz-ui-constants";
 
 import { WizProgressBar } from "../components";
 import { ProgressItem } from "../types";
@@ -6,6 +10,24 @@ import { ProgressItem } from "../types";
 const meta: Meta<typeof WizProgressBar> = {
   title: "Base/Progress/Bar",
   component: WizProgressBar,
+  argTypes: {
+    labelColor: {
+      control: { type: "select" },
+      options: COLOR_MAP_ACCESSORS,
+    },
+    labelSize: {
+      control: { type: "select" },
+      options: FONT_SIZE_ACCESSORS,
+    },
+    annotationColor: {
+      control: { type: "select" },
+      options: COLOR_MAP_ACCESSORS,
+    },
+    annotationSize: {
+      control: { type: "select" },
+      options: FONT_SIZE_ACCESSORS,
+    },
+  },
   decorators: [
     (Story) => (
       <div style={{ padding: "100px" }}>
@@ -25,7 +47,7 @@ const contents: ProgressItem[] = [
     tooltip: "Tooltip 1",
     status: "done",
     value: 1,
-    progress: true,
+    progress: "active",
   },
   {
     id: "2",
@@ -34,7 +56,7 @@ const contents: ProgressItem[] = [
     label: "Label 2",
     status: "active",
     value: 2,
-    progress: true,
+    progress: "active",
   },
   {
     id: "3",
@@ -43,7 +65,7 @@ const contents: ProgressItem[] = [
     label: "Label 3",
     status: "inactive",
     value: 3,
-    progress: true,
+    progress: "inactive",
   },
   {
     id: "4",
@@ -52,7 +74,7 @@ const contents: ProgressItem[] = [
     label: "Label 4",
     status: "pending",
     value: 4,
-    progress: true,
+    progress: "active",
   },
   {
     id: "5",
@@ -61,7 +83,7 @@ const contents: ProgressItem[] = [
     label: "Label 5",
     status: "dead",
     value: 5,
-    progress: true,
+    progress: "inactive",
   },
   {
     id: "6",
@@ -70,7 +92,16 @@ const contents: ProgressItem[] = [
     label: "Label 6",
     status: "none",
     value: 6,
-    progress: true,
+    progress: "inactive",
+  },
+  {
+    id: "7",
+    annotation: "Annotation 7",
+    tooltip: "Tooltip 7",
+    label: "Label 7",
+    status: "rejected",
+    value: 7,
+    progress: "rejected",
   },
 ];
 
@@ -136,5 +167,44 @@ export const WithAnnotation: Story = {
 export const WithAll: Story = {
   args: {
     contents: contents,
+  },
+};
+
+export const WithCustomLabel: Story = {
+  args: {
+    contents: contents.map((content) => ({
+      id: content.id,
+      status: content.status,
+      label: content.label,
+    })),
+    labelColor: "blue.800",
+    labelSize: "md",
+  },
+};
+
+export const WithCustomAnnotation: Story = {
+  args: {
+    contents: contents.map((content) => ({
+      id: content.id,
+      status: content.status,
+      annotation: content.annotation,
+    })),
+    annotationColor: "green.800",
+    annotationSize: "md",
+  },
+};
+
+export const WithCustomLabelAndAnnotation: Story = {
+  args: {
+    contents: contents.map((content) => ({
+      id: content.id,
+      status: content.status,
+      label: content.label,
+      annotation: content.annotation,
+    })),
+    labelColor: "blue.800",
+    labelSize: "md",
+    annotationColor: "green.800",
+    annotationSize: "md",
   },
 };

--- a/packages/wiz-ui-react/src/components/base/progress-bar/stories/progress-point.stories.tsx
+++ b/packages/wiz-ui-react/src/components/base/progress-bar/stories/progress-point.stories.tsx
@@ -46,6 +46,12 @@ export const None: Story = {
   },
 };
 
+export const Rejected: Story = {
+  args: {
+    status: "rejected",
+  },
+};
+
 export const WithValue: Story = {
   render: (args) => {
     const status: ProgressStatus[] = [
@@ -55,6 +61,7 @@ export const WithValue: Story = {
       "pending",
       "dead",
       "none",
+      "rejected",
     ];
 
     return (

--- a/packages/wiz-ui-react/src/components/base/progress-bar/types/progress-item.ts
+++ b/packages/wiz-ui-react/src/components/base/progress-bar/types/progress-item.ts
@@ -4,7 +4,10 @@ export type ProgressStatus =
   | "inactive"
   | "none"
   | "pending"
-  | "dead";
+  | "dead"
+  | "rejected";
+
+export type ProgressState = "active" | "inactive" | "rejected";
 
 export interface ProgressItem {
   id: string;
@@ -12,6 +15,6 @@ export interface ProgressItem {
   label?: string;
   annotation?: string;
   tooltip?: string;
-  progress?: boolean;
+  progress?: ProgressState;
   value?: number;
 }

--- a/packages/wiz-ui-react/src/components/base/progress-bar/types/progress-item.ts
+++ b/packages/wiz-ui-react/src/components/base/progress-bar/types/progress-item.ts
@@ -1,3 +1,5 @@
+import { ColorKeys, FontSizeKeys } from "@wizleap-inc/wiz-ui-constants";
+
 export type ProgressStatus =
   | "done"
   | "active"
@@ -17,4 +19,8 @@ export interface ProgressItem {
   tooltip?: string;
   progress?: ProgressState;
   value?: number;
+  labelColor?: ColorKeys;
+  labelSize?: FontSizeKeys;
+  annotationColor?: ColorKeys;
+  annotationSize?: FontSizeKeys;
 }


### PR DESCRIPTION
- ProgressStatusに"rejected"を追加（赤の破線ボーダー・ピンク背景）
- WizProgressBarにlabelColor/labelSize/annotationColor/annotationSizeを追加
- ProgressItem.progressをbooleanから"active"|"inactive"|"rejected"に変更（破壊的変更）
- WizProgressLineのpropsをactive:booleanからstate:ProgressStateに変更（破壊的変更）
- pointとlabel/annotationの間に4pxの余白を追加

# タスク

resolve: #1661

<!-- reviewerにオーナーを追加してください-->
